### PR TITLE
開始日と期日に日付に変換できない文字列が入っていた場合の挙動の修正

### DIFF
--- a/app/controllers/importer_controller.rb
+++ b/app/controllers/importer_controller.rb
@@ -404,14 +404,20 @@ class ImporterController < ApplicationController
       issue.done_ratio = row[attrs_map["done_ratio"]] || issue.done_ratio
       issue.estimated_hours = row[attrs_map["estimated_hours"]] || issue.estimated_hours
 
-      ["start_date", "due_date"].each do |date_attr|
-        begin
-          issue.send("#{date_attr}=", Date.parse(row[attrs_map[date_attr]])) if row[attrs_map[date_attr]].present?
-        rescue ArgumentError
-          @failed_count += 1
-          @failed_issues[@failed_count] = row
-          @messages << "Warning: When setting the #{date_attr} for issue #{@failed_count}, #{row[attrs_map[date_attr]]} is not valid date"
-        end
+      begin
+        issue.start_date = Date.parse(row[attrs_map["start_date"]]) if row[attrs_map["start_date"]].present?
+      rescue ArgumentError
+        @failed_count += 1
+        @failed_issues[@failed_count] = row
+        @messages << "Warning: When setting the start_date for issue #{@failed_count}, #{row[attrs_map["start_date"]]} is not valid date"
+      end
+
+      begin
+        issue.due_date = Date.parse(row[attrs_map["due_date"]]) if row[attrs_map["due_date"]].present?
+      rescue ArgumentError
+        @failed_count += 1
+        @failed_issues[@failed_count] = row
+        @messages << "Warning: When setting the start_date for issue #{@failed_count}, #{row[attrs_map["due_date"]]} is not valid date"
       end
 
       # parent issues

--- a/app/controllers/importer_controller.rb
+++ b/app/controllers/importer_controller.rb
@@ -399,12 +399,20 @@ class ImporterController < ApplicationController
       issue.description = description ?
           description.gsub(/\r\n?|\\n|<br\s*\/?>/, "\n") : issue.description
       issue.category_id = category != nil ? category.id : issue.category_id
-      issue.start_date = row[attrs_map["start_date"]].blank? ? nil : Date.parse(row[attrs_map["start_date"]])
-      issue.due_date = row[attrs_map["due_date"]].blank? ? nil : Date.parse(row[attrs_map["due_date"]])
       issue.assigned_to_id = assigned_to != nil ? assigned_to.id : issue.assigned_to_id
       issue.fixed_version_id = fixed_version_id != nil ? fixed_version_id : issue.fixed_version_id
       issue.done_ratio = row[attrs_map["done_ratio"]] || issue.done_ratio
       issue.estimated_hours = row[attrs_map["estimated_hours"]] || issue.estimated_hours
+
+      ["start_date", "due_date"].each do |date_attr|
+        begin
+          issue.send("#{date_attr}=", Date.parse(row[attrs_map[date_attr]])) if row[attrs_map[date_attr]].present?
+        rescue ArgumentError
+          @failed_count += 1
+          @failed_issues[@failed_count] = row
+          @messages << "Warning: When setting the #{date_attr} for issue #{@failed_count}, #{row[attrs_map[date_attr]]} is not valid date"
+        end
+      end
 
       # parent issues
       begin


### PR DESCRIPTION
現状、開始日もしくは期日に使用する列に、`Date.parse` で変換できないデータが入っていると、ArgumentError で落ちます。

この修正により、開始日や期日に日付として不正な文字列が入っていても、Warning をユーザに表示することができるようになります。