### PR TITLE
CSVにブランクのIDが含まれている時に例外を吐くバグを修正

### DIFF
--- a/app/controllers/importer_controller.rb
+++ b/app/controllers/importer_controller.rb
@@ -138,7 +138,7 @@ class ImporterController < ApplicationController
     end
 
     if unique_attr == "id"
-      issues = [Issue.find_by_id(attr_value)]
+      issues = [Issue.find_by_id(attr_value)].compact
     else
       # Use IssueQuery class Redmine >= 2.3.0
       begin


### PR DESCRIPTION
ユニークフィールドにidを指定して、かつCSVにid列がブランクなセルがあるときに、例外を吐いて落ちるという問題があったので修正しました。

https://www.pivotaltracker.com/n/projects/1184622/stories/93669560
https://redmine.agileware.jp/issues/866