### PR TITLE
Continue to create an issue even the unique issue doesn't find.

### DIFF
--- a/app/controllers/importer_controller.rb
+++ b/app/controllers/importer_controller.rb
@@ -340,6 +340,7 @@ class ImporterController < ApplicationController
 
       if update_issue
         begin
+          reserved_issue_for_exception = issue
           issue = issue_for_unique_attr(unique_attr,row[unique_field],row)
 
           # ignore other project's issue or not
@@ -368,10 +369,8 @@ class ImporterController < ApplicationController
             @skip_count += 1
             next
           else
-            @failed_count += 1
-            @failed_issues[@failed_count] = row
-            @messages << "Warning: Could not update issue #{@failed_count} below, no match for the value #{row[unique_field]} were found"
-            next
+            # continue to create an issue even there is no unique issue.
+            issue = reserved_issue_for_exception
           end
 
         rescue MultipleIssuesForUniqueValue


### PR DESCRIPTION
I fixed the behavior that cause only updating issues.
This modification allows updating and creating issue at the same time.

(this code depends on exception, but it is not good design i think.
So i wanna fix it at some future time...)