### PR TITLE
ガントチャートのチケット編集フォームなどからチケットを編集したとき、チケットに変更履歴が残るようにした

### DIFF
--- a/app/controllers/importer_controller.rb
+++ b/app/controllers/importer_controller.rb
@@ -4,12 +4,6 @@ require 'tempfile'
 MultipleIssuesForUniqueValue = Class.new(Exception)
 NoIssueForUniqueValue = Class.new(Exception)
 
-Journal.class_eval do
-  def empty?(*args)
-    (details.empty? && notes.blank?)
-  end
-end
-
 class ImporterController < ApplicationController
   unloadable
 
@@ -270,7 +264,7 @@ class ImporterController < ApplicationController
         if send_emails
           if update_issue
             if Setting.notified_events.include?('issue_updated') \
-               && (!issue.current_journal.empty?)
+               && (!(issue.current_journal.details.empty? && issue.current_journal.notes.blank?))
 
               Mailer.deliver_issue_edit(issue.current_journal)
             end


### PR DESCRIPTION
`Journal#empty?` メソッドが定義されていると `issue.current_journal.blank?` が違う値を返してしまうためうまく動かなくなる
https://github.com/rails/rails/blob/57ae917e9d52c9472fd37adbfa47d6de93dd01bf/activesupport/lib/active_support/core_ext/object/blank.rb#L19