### PR TITLE
Fix occurring ArgumentError when same name custom field as standard field is exists

### DIFF
--- a/app/helpers/importer_helper.rb
+++ b/app/helpers/importer_helper.rb
@@ -2,7 +2,7 @@ module ImporterHelper
   def matched_attrs(column)
     matched = ''
     @attrs.each do |k,v|
-      if v.to_s.casecmp(column.to_s.sub(" ") {|sp| "_" }) == 0 \
+      if v.to_s[/(?<=-).*/].casecmp(column.to_s.sub(" ") {|sp| "_" }) == 0 \
         || k.to_s.casecmp(column.to_s) == 0
 
         matched = v

--- a/test/functional/importer_controller_test.rb
+++ b/test/functional/importer_controller_test.rb
@@ -125,7 +125,7 @@ class ImporterControllerTest < ActionController::TestCase
   test 'should handle issue relation' do
     other_issue = create_issue!(@project, @user, { subject: 'other_issue' })
     @iip.update!(csv_data: "#,Subject,Duplicated issue ID\n#{@issue.id},set other issue relation,#{other_issue.id}\n")
-    post :result, params: build_params(update_issue: 'true').tap { |params| params[:fields_map]['Duplicated issue ID'] = IssueRelation::TYPE_DUPLICATED }
+    post :result, params: build_params(update_issue: 'true').tap { |params| params[:fields_map]['Duplicated issue ID'] = "issue_relation-#{IssueRelation::TYPE_DUPLICATED}" }
     assert_response :success
     @issue.reload
     assert_equal 'set other issue relation', @issue.subject
@@ -138,7 +138,7 @@ class ImporterControllerTest < ActionController::TestCase
   test 'should error when assigned_to is missing' do
     @iip.update!(csv_data: "#,Subject,assigned_to\n#{@issue.id},barfooz,JohnDoe\n")
     @issue.update!(assigned_to: @user)
-    post :result, params: build_params(update_issue: 'true').tap { |params| params[:fields_map]['assigned_to'] = 'assigned_to' }
+    post :result, params: build_params(update_issue: 'true').tap { |params| params[:fields_map]['assigned_to'] = 'standard_field-assigned_to' }
     assert_response :success
     assert response.body.include?('Warning')
     @issue.reload
@@ -149,7 +149,7 @@ class ImporterControllerTest < ActionController::TestCase
   test 'should unset assigned_to when assigned_to user is not assignable' do
     User.create!(login: 'john', firstname: 'John', lastname: 'Doe', mail: 'john.doe@example.com')
     @iip.update!(csv_data: "#,Subject,assigned_to\n#{@issue.id},barfooz,john\n")
-    post :result, params: build_params(update_issue: 'true').tap { |params| params[:fields_map]['assigned_to'] = 'assigned_to' }
+    post :result, params: build_params(update_issue: 'true').tap { |params| params[:fields_map]['assigned_to'] = 'standard_field-assigned_to' }
     assert_response :success
     assert !response.body.include?('Warning')
     @issue.reload
@@ -164,7 +164,7 @@ class ImporterControllerTest < ActionController::TestCase
     @issue.custom_field_values.detect { |cfv| cfv.custom_field == assigned_by_field }.value = @user
     @iip.update!(csv_data: "#,Subject,assigned_by\n#{@issue.id},barfooz,JeanDoe\n")
     @issue.update!(assigned_to: @user)
-    post :result, params: build_params(update_issue: 'true').tap { |params| params[:fields_map]['assigned_by'] = 'assigned_by' }
+    post :result, params: build_params(update_issue: 'true').tap { |params| params[:fields_map]['assigned_by'] = 'standard_field-assigned_by' }
     assert_response :success
     assert response.body.include?('Warning')
     @issue.reload
@@ -175,7 +175,7 @@ class ImporterControllerTest < ActionController::TestCase
   test 'should not error when assigned_to is missing but use_anonymous is true' do
     @iip.update!(csv_data: "#,Subject,assigned_to\n#{@issue.id},barfooz,JohnDoe\n")
     @issue.update!(assigned_to: @user)
-    post :result, params: build_params(update_issue: 'true', use_anonymous: 'true').tap { |params| params[:fields_map]['assigned_to'] = 'assigned_to' }
+    post :result, params: build_params(update_issue: 'true', use_anonymous: 'true').tap { |params| params[:fields_map]['assigned_to'] = 'standard_field-assigned_to' }
     assert_response :success
     assert !response.body.include?('Warning')
     @issue.reload
@@ -190,7 +190,7 @@ class ImporterControllerTest < ActionController::TestCase
     @issue.custom_field_values.detect { |cfv| cfv.custom_field == assigned_by_field }.value = @user
     @iip.update!(csv_data: "#,Subject,assigned_by\n#{@issue.id},barfooz,JeanDoe\n")
     @issue.update!(assigned_to: @user)
-    post :result, params: build_params(update_issue: 'true', use_anonymous: 'true').tap { |params| params[:fields_map]['assigned_by'] = 'assigned_by' }
+    post :result, params: build_params(update_issue: 'true', use_anonymous: 'true').tap { |params| params[:fields_map]['assigned_by'] = 'custom_field-assigned_by' }
     assert_response :success
     assert !response.body.include?('Warning')
     @issue.reload
@@ -206,7 +206,7 @@ class ImporterControllerTest < ActionController::TestCase
     @issue.custom_field_values.detect { |cfv| cfv.custom_field == assigned_by_field }.value = @user
     @iip.update!(csv_data: "#,Subject,assigned_by\n#{@issue.id},barfooz,john\n")
     @issue.update!(assigned_to: @user)
-    post :result, params: build_params(update_issue: 'true', use_anonymous: 'true').tap { |params| params[:fields_map]['assigned_by'] = 'assigned_by' }
+    post :result, params: build_params(update_issue: 'true', use_anonymous: 'true').tap { |params| params[:fields_map]['assigned_by'] = 'custom_field-assigned_by' }
     assert_response :success
     assert !response.body.include?('Warning')
     @issue.reload
@@ -244,15 +244,15 @@ class ImporterControllerTest < ActionController::TestCase
       unique_field: '#',
       project_id: @project.id,
       fields_map: {
-        '#' => 'id',
-        'Subject' => 'subject',
-        'Tags' => 'Tags',
-        'Affected versions' => 'Affected versions',
-        'Priority' => 'priority',
-        'Tracker' => 'tracker',
-        'Status' => 'status',
-        'Watchers' => 'watchers',
-        'Area' => 'Area'
+        '#' => 'standard_field-id',
+        'Subject' => 'standard_field-subject',
+        'Tags' => 'custom_field-Tags',
+        'Affected versions' => 'custom_field-Affected versions',
+        'Priority' => 'standard_field-priority',
+        'Tracker' => 'standard_field-tracker',
+        'Status' => 'standard_field-status',
+        'Watchers' => 'standard_field-watchers',
+        'Area' => 'custom_field-Area'
       }
     )
   end


### PR DESCRIPTION
Story: https://insidemine.agileware.jp/issues/45521

### 発生条件

標準項目と同じ名前のカスタムフィールドが存在し，redmine_importerでCSVのアップロードを行ったとき．

### 原因

以下にて，Symbolと文字列の比較を行ってArgumentErrorになっていた．

https://github.com/agileware-jp/redmine_importer/blob/aad2d94815c271ac939b26f4d79f708c862b5756/app/controllers/importer_controller.rb#L66

以下はJapanese(日本語)のユーザーで「カテゴリ」という名前のカスタムフィールドを用意した場合

```
irb(main):022:0> [["カテゴリ", :category], ["カテゴリ", "カテゴリ"]].sort
Traceback (most recent call last):
        6: from /home/yuya/.anyenv/envs/rbenv/versions/2.6.6/bin/irb:23:in `<main>'
        5: from /home/yuya/.anyenv/envs/rbenv/versions/2.6.6/bin/irb:23:in `load'
        4: from /home/yuya/.anyenv/envs/rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
        3: from (irb):22
        2: from (irb):22:in `rescue in irb_binding'
        1: from (irb):22:in `sort'
ArgumentError (comparison of Array with Array failed)
```

### 対応方法

- sort!する配列にSymbolを含めず，常に文字列で比較するようにした．
- 標準項目とカスタムフィールドの名前が一致する場合でも区別してインポートできるように/importer/resultの`params[:fields_map]`の値に以下のprefixを用意した．（https://insidemine.agileware.jp/issues/45521#note-10 末尾の松案）
    - 標準項目: `standard_field-`
    - カスタムフィールド: `custom_field-`
    - Issue間の関連: `issue_relation-`

### 影響範囲

- /importer/match
- /importer/result の各種条件
