### PR TITLE
Support user matching by display name for all user-type fields

### DIFF
--- a/app/controllers/importer_controller.rb
+++ b/app/controllers/importer_controller.rb
@@ -703,7 +703,10 @@ class ImporterController < ApplicationController
     return @user_by_login[login] if @user_by_login.key?(login)
 
     begin
-      user = Principal.detect_by_keyword(User.includes(:email_address), login)
+      # Load all users once and cache them for the entire import session
+      @all_users ||= User.includes(:email_address).to_a
+
+      user = Principal.detect_by_keyword(@all_users, login)
 
       if user.nil?
         raise ActiveRecord::RecordNotFound

--- a/app/controllers/importer_controller.rb
+++ b/app/controllers/importer_controller.rb
@@ -696,13 +696,20 @@ class ImporterController < ApplicationController
     end
   end
 
-  # Returns the id for the given user or raises RecordNotFound
-  # Implements a cache of users based on login name
+  # Returns the user matching the given keyword or raises RecordNotFound
+  # Matches by login, mail, firstname+lastname, or display name
+  # Implements a cache of users based on the keyword
   def user_for_login!(login)
+    return @user_by_login[login] if @user_by_login.key?(login)
+
     begin
-      unless @user_by_login.key?(login)
-        @user_by_login[login] = User.find_by_login!(login)
+      user = Principal.detect_by_keyword(User.includes(:email_address), login)
+
+      if user.nil?
+        raise ActiveRecord::RecordNotFound
       end
+
+      @user_by_login[login] = user
     rescue ActiveRecord::RecordNotFound
       if params[:use_anonymous]
         @user_by_login[login] = User.anonymous
@@ -712,6 +719,7 @@ class ImporterController < ApplicationController
         raise
       end
     end
+
     @user_by_login[login]
   end
 

--- a/test/functional/importer_controller_test.rb
+++ b/test/functional/importer_controller_test.rb
@@ -193,6 +193,21 @@ class ImporterControllerTest < ActionController::TestCase
     assert_nil @issue.assigned_to
   end
 
+  test 'should match assigned_to by user display name' do
+    user = User.find_by_login('jsmith')
+    Member.create!(user: user, project: @project, roles: [@role])
+
+    @iip.update!(csv_data: "#,Subject,assigned_to\n#{@issue.id},barfooz,#{user.name}\n")
+    post :result, params: build_params(update_issue: 'true').tap { |params|
+                            params[:fields_map]['assigned_to'] = 'standard_field-assigned_to'
+                          }
+    assert_response :success
+    assert_not response.body.include?('Warning')
+    @issue.reload
+    assert_equal 'barfooz', @issue.subject
+    assert_equal user, @issue.assigned_to
+  end
+
   test 'should not error when user type CF value is missing but use_anonymous is true' do
     assigned_by_field = create_multivalue_field!('assigned_by', 'user', @issue.project)
     @tracker.custom_fields << assigned_by_field

--- a/test/functional/importer_controller_test.rb
+++ b/test/functional/importer_controller_test.rb
@@ -5,6 +5,8 @@ require File.expand_path('../test_helper', __dir__)
 class ImporterControllerTest < ActionController::TestCase
   include ActiveJob::TestHelper
 
+  fixtures :users
+
   def setup
     ActionController::Base.allow_forgery_protection = false
     @project = Project.create! name: 'foo', identifier: 'importer_controller_test'


### PR DESCRIPTION
Use Principal.detect_by_keyword to match users by login, mail,
firstname+lastname, or display name when importing user-type fields
(assigned_to, author, watchers, and user-type custom fields).
This aligns with Redmine's core IssueImport implementation.

Previously, only login-based matching was supported via User.find_by_login.
Now users can be matched by their display name (User.name), making CSV
imports more flexible and user-friendly.
