### PR TITLE
Orb version increased

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  redmine-plugin: agileware-jp/redmine-plugin@3.9.0
+  redmine-plugin: agileware-jp/redmine-plugin@4.0.1
 
 jobs:
   run-tests-git-url:

--- a/Gemfile.local
+++ b/Gemfile.local
@@ -1,3 +1,5 @@
+gem 'minitest', '~> 5.27' # Pin to 5.x — minitest 6.0 is incompatible with Rails 7.2.x (Redmine #43609)
+
 group :test do
   dependencies.reject! { |i| i.name == 'nokogiri' } # Ensure Nokogiri have new version
 end

--- a/Gemfile.local
+++ b/Gemfile.local
@@ -1,4 +1,5 @@
-gem 'minitest', '~> 5.27' # Pin to 5.x — minitest 6.0 is incompatible with Rails 7.2.x (Redmine #43609)
+# Pin minitest to 5.x if Redmine hasn't already — minitest 6.0 is incompatible with Rails 7.2.x (Redmine #43609)
+gem 'minitest', '< 6.0' unless dependencies.any? { |d| d.name == 'minitest' }
 
 group :test do
   dependencies.reject! { |i| i.name == 'nokogiri' } # Ensure Nokogiri have new version

--- a/app/controllers/importer_controller.rb
+++ b/app/controllers/importer_controller.rb
@@ -501,13 +501,12 @@ class ImporterController < ApplicationController
 
     watcher_failed_count = 0
     if watchers
-      addable_watcher_users = issue.addable_watcher_users
       watchers.split(',').each do |watcher|
         begin
           watcher_user = user_for_login!(watcher)
           next if issue.watcher_users.include?(watcher_user)
 
-          if addable_watcher_users.include?(watcher_user)
+          if issue.valid_watcher?(watcher_user)
             issue.add_watcher(watcher_user)
           end
         rescue ActiveRecord::RecordNotFound


### PR DESCRIPTION
### minitest 6.0 互換性問題の修正

  Redmine git（trunk）ジョブで `minitest 6.0.2` が解決され、Rails 7.2.x の `LineFiltering#run`
  との引数不一致で全テストがクラッシュしていた（[Redmine #43609](https://www.redmine.org/issues/43609)）。

  Redmine 本体は stable ブランチで `minitest < 6.0` を固定済みだが、`$REDMINE_GIT_REVISION`
  が固定前のリビジョンを指す可能性もあるため、`Gemfile.local` に条件付きで minitest を固定するようにした。Redmine
  側で既に固定されている場合はスキップし、重複gem宣言エラーを回避する。

  ```ruby
  gem 'minitest', '< 6.0' unless dependencies.any? { |d| d.name == 'minitest' }
```

###  addable_watcher_users → valid_watcher? への置換

  Redmine trunk で `addable_watcher_users` が削除される可能性があるため、`valid_watcher?` に置換した。valid_watcher? は
  `acts_as_watchable` で定義されており、`Redmine 6.0.3` 以降で利用可能。

 ### 変更ファイル

  - `Gemfile.local` — 条件付き minitest 5.x 固定を追加
  - `app/controllers/importer_controller.rb` — ウォッチャー判定メソッドを変更