### PR TITLE
Fix submit button label override on Redmine core forms

### DIFF
--- a/app/views/importer/match.html.erb
+++ b/app/views/importer/match.html.erb
@@ -106,7 +106,7 @@
     <br/>
   </fieldset>
 
-  <%= submit_tag l(:button_submit), :id => 'import-button' %>
+  <%= submit_tag l(:button_redmine_importer_submit), :id => 'import-button' %>
   <br/>
 <% end %>
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -32,7 +32,7 @@ de:
     option_ignore: "Ignorieren"
     
     button_upload: "Datei hochladen"
-    button_submit: "Abschicken"
+    button_redmine_importer_submit: "Abschicken"
     button_save_rules_and_submit: "Abschicken und Abgleich-Regel speichern"
 
     text_rmi_specify_unique_field_for_update: "Ein eindeutiges Feld muss definiert sein, da die Einstellung für das Update von bestehenden Tickets gesetzt ist."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,7 +34,7 @@ en:
   option_ignore: "Ignore"
 
   button_upload: "Upload File"
-  button_submit: "Submit"
+  button_redmine_importer_submit: "Submit"
   button_save_rules_and_submit: "Save match rules and submit"
 
   text_rmi_specify_unique_field_for_update: "Unique field must be specified because Update existing issues is on"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -34,7 +34,7 @@ ja:
   option_ignore: "無視"
 
   button_upload: "ファイルをアップロード"
-  button_submit: "確認"
+  button_redmine_importer_submit: "確認"
   button_save_rules_and_submit: "対応ルールを保存して確認"
 
   text_rmi_specify_unique_field_for_update: "存在するチケットを更新する場合、ユニークフィールドを選択する必要があります。"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -32,7 +32,7 @@ pt-BR:
   option_ignore: "Ignorar"
   
   button_upload: "Enviar arquivo"
-  button_submit: "Enviar"
+  button_redmine_importer_submit: "Enviar"
   button_save_rules_and_submit: "Salvar regra de mapeamento e enviar"
 
   label_importer_use_issue_id: "Import using issue ids"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -32,7 +32,7 @@ ru:
   option_ignore: "Игнорировать"
 
   button_upload: "Загрузить файл"
-  button_submit: "Импортировать"
+  button_redmine_importer_submit: "Импортировать"
   button_save_rules_and_submit: "Save match rules and submit"
 
   text_rmi_specify_unique_field_for_update: "Колонка с уникальными значениями должна быть определена, так как включен режим обновления существующих задач включен"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -33,7 +33,7 @@ zh:
   option_ignore: "忽略"
   
   button_upload: "上传文件"
-  button_submit: "提交"
+  button_redmine_importer_submit: "提交"
   button_save_rules_and_submit: "存储匹配规则后提交"
 
   text_rmi_specify_unique_field_for_update: "更新现有问题时，必须填写必填字段内容！"


### PR DESCRIPTION
## Summary
- The plugin's `button_submit` locale key collided with Redmine core's standard translation key. Because plugin locales are merged into the host application, the plugin was overwriting the core translation, so every submit button across Redmine (issue create/update forms, member forms, etc.) was rendered with the plugin's value (e.g. "確認" in Japanese instead of the core "送信").
- Renamed the key to `button_redmine_importer_submit` across all six locale files (`ja`, `en`, `pt-BR`, `de`, `ru`, `zh`) and updated the sole consumer at `app/views/importer/match.html.erb`.
- The importer's own UI is unchanged (the match-page button still shows "確認" / "Submit" / etc.); only Redmine core labels are restored to their standard wording.

## Out of scope (noted for future cleanup)
- `button_save_rules_and_submit` is a leftover from a never-shipped "save mapping rules" feature (commented out at initial import in 2009, removed from the view in 2014, but the locale entries were never deleted). It is no longer referenced and could be removed.
- `button_upload` does not exist in Redmine core today and therefore does not currently collide, but adopting the same `button_redmine_importer_*` namespace would harden it against future or third-party collisions.

## Test plan
- [ ] Open a Redmine core issue creation/update form and confirm the submit button shows the core's standard label (e.g. "送信" in Japanese), not "確認".
- [ ] Open the importer match page and confirm the submit button still shows the importer's translation (e.g. "確認" in Japanese).
- [ ] `grep -rn button_submit` returns no matches inside the plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)