### PR TITLE
Bump version to 2.0.2

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -11,7 +11,7 @@ Redmine::Plugin.register :redmine_importer do
   name 'Issue Importer'
   author 'Martin Liu / Leo Hourvitz / Stoyan Zhekov / Jérôme Bataille / Agileware Inc.'
   description 'Issue import plugin for Redmine.'
-  version '2.0.1'
+  version '2.0.2'
 
   settings default: { 'max_csv_rows' => '5000' },
            partial: 'settings/redmine_importer_settings'


### PR DESCRIPTION
## Summary
- Bump plugin version from 2.0.1 to 2.0.2

## Test plan
- [ ] Verify version is displayed as 2.0.2 in Redmine plugin list

🤖 Generated with [Claude Code](https://claude.com/claude-code)