### PR TITLE
fix: 新しい Redmine で watcher 追加が NoMethodError になる問題を修正

### DIFF
--- a/app/controllers/importer_controller.rb
+++ b/app/controllers/importer_controller.rb
@@ -529,13 +529,12 @@ class ImporterController < ApplicationController
 
     watcher_failed_count = 0
     if watchers
-      addable_watcher_users = issue.addable_watcher_users
       watchers.split(',').each do |watcher|
         begin
           watcher_user = user_for_login!(watcher)
           next if issue.watcher_users.include?(watcher_user)
 
-          if addable_watcher_users.include?(watcher_user)
+          if issue.valid_watcher?(watcher_user)
             issue.add_watcher(watcher_user)
           end
         rescue ActiveRecord::RecordNotFound


### PR DESCRIPTION
## 概要

Redmine **7.0.0**（およびそれ以降 / master）で CSV インポート時の watcher 追加が `NoMethodError` で失敗する問題を修正します。

## 原因

`ImporterController#handle_watchers` で `Issue#addable_watcher_users` を呼び出していますが、このメソッド（`acts_as_watchable` の InstanceMethods 由来）は Redmine 7.0.0 で削除されました（redmine/redmine#43429, 2025-12-18 の削除コミットが 7.0.0 に取り込まれた）。

```
NoMethodError: undefined method 'addable_watcher_users' for an instance of Issue
```

Redmine 6.x 以下には同メソッドが存在するため CI の最小バージョン（5.x）や 6.x では通っていましたが、CI の git 版ジョブが実際に引いていた **Redmine 7.0.0** では 8 件の error が発生していました。

## 修正内容

事前に候補ユーザー一覧を取得して `include?` で判定する方式から、`acts_as_watchable` が新旧ともに提供している `Issue#valid_watcher?(user)` でユーザーごとに判定する方式に変更しました。`valid_watcher?` は Redmine 7.0.0 にも存在するため、新旧どちらの Redmine でも動作します。

既存の `should add watchers` テストがこの挙動をカバーしています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### TestCafe実行結果

最新の結果: https://github.com/agileware-jp/redmine_importer/pull/47#issuecomment-5389799648
