### PR TITLE
fix: rubygems 4 で commonmarker の bundle install が失敗する問題を修正

### DIFF
--- a/Gemfile.local
+++ b/Gemfile.local
@@ -1,6 +1,14 @@
 # Pin minitest to 5.x if Redmine hasn't already — minitest 6.0 is incompatible with Rails 7.2.x (Redmine #43609)
 gem 'minitest', '< 6.0' unless dependencies.any? { |d| d.name == 'minitest' }
 
+# rubygems 4 で bundle install が失敗する件の対応
+# commonmarker 2.3.0 は rubygems ~> 3.4 を要求するため、rubygems 4 だと依存解決に失敗する。
+# rubygems 4 に対応した 2.8.2 に差し替える。
+if RUBY_VERSION >= '3.2'
+  dependencies.reject! { |i| i.name == 'commonmarker' }
+  gem 'commonmarker', '~> 2.8.2'
+end
+
 group :test do
   dependencies.reject! { |i| i.name == 'nokogiri' } # Ensure Nokogiri have new version
 end

--- a/Gemfile.local
+++ b/Gemfile.local
@@ -1,9 +1,8 @@
 # Pin minitest to 5.x if Redmine hasn't already — minitest 6.0 is incompatible with Rails 7.2.x (Redmine #43609)
 gem 'minitest', '< 6.0' unless dependencies.any? { |d| d.name == 'minitest' }
 
-# rubygems 4 で bundle install が失敗する件の対応
-# commonmarker 2.3.0 は rubygems ~> 3.4 を要求するため、rubygems 4 だと依存解決に失敗する。
-# rubygems 4 に対応した 2.8.2 に差し替える。
+# Work around bundle install failing on RubyGems 4 — commonmarker 2.3.0 requires
+# RubyGems ~> 3.4, so replace it with 2.8.2 which supports RubyGems 4.
 if RUBY_VERSION >= '3.2'
   dependencies.reject! { |i| i.name == 'commonmarker' }
   gem 'commonmarker', '~> 2.8.2'


### PR DESCRIPTION
## 概要

CI（rubygems 4 系の環境）で `bundle install` が commonmarker の依存解決に失敗する問題を修正します。

## 原因

Redmine 6.1 系が固定している `commonmarker ~> 2.3.0` は、gemspec で `required_rubygems_version = ~> 3.4` を要求しています。CI 環境の rubygems が 4.x になったため、次のように依存解決が失敗していました。

```
Because commonmarker >= 2.0.2, < 2.6.0 depends on RubyGems ~> 3.4
  and Gemfile depends on commonmarker ~> 2.3.0,
  RubyGems ~> 3.4 is required.
So, because current RubyGems version is = 4.0.15,
  version solving has failed.
```

commonmarker は 2.6.0 以降で `required_rubygems_version` が `>= 3.4` に緩和され、rubygems 4.x でも解決できます。

## 修正内容

`Gemfile.local` で Redmine 側の commonmarker 依存を一旦除去し、rubygems 4.x に対応した `~> 2.8.2` を指定するようにしました。2.8.2 は Redmine 7.0 が採用している版でもあるため、新しい Redmine との API 互換性の懸念もありません。

`lychee-dev-dependencies` の同種の対応（`~> 2.6.0`）を参考にしていますが、こちらは実際に CI が引く Redmine のバージョンに合わせて `~> 2.8.2` としています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)