### PR TITLE
perf: eliminate N+1 queries for reference master lookups

### DIFF
--- a/app/controllers/importer_controller.rb
+++ b/app/controllers/importer_controller.rb
@@ -147,7 +147,7 @@ class ImporterController < ApplicationController
                 quote_char: iip.quote_char,
                 col_sep: iip.col_sep }
     CSV.new(iip.csv_data, **csv_opt).each do |row|
-      project = Project.find_by_name(fetch('standard_field-project', row))
+      project = @project_by_name[fetch('standard_field-project', row)]
       project ||= @project
 
       begin
@@ -163,17 +163,16 @@ class ImporterController < ApplicationController
 
         issue.id = fetch('standard_field-id', row) if use_issue_id
 
-        tracker = Tracker.find_by_name(fetch('standard_field-tracker', row))
-        status = IssueStatus.find_by_name(fetch('standard_field-status', row))
+        tracker = @tracker_by_name[fetch('standard_field-tracker', row)]
+        status = @status_by_name[fetch('standard_field-status', row)]
         author = if @attrs_map.key?('standard_field-author') && @attrs_map['standard_field-author']
                    user_for_login!(fetch('standard_field-author', row))
                  else
                    User.current
                  end
-        priority = Enumeration.find_by_name(fetch('standard_field-priority', row))
+        priority = @priority_by_name[fetch('standard_field-priority', row)]
         category_name = fetch('standard_field-category', row)
-        category = IssueCategory.find_by_project_id_and_name(project.id,
-                                                             category_name)
+        category = @category_by_project_and_name[[project.id, category_name]]
 
         if !category \
           && category_name && !category_name.empty? \
@@ -181,6 +180,9 @@ class ImporterController < ApplicationController
 
           category = project.issue_categories.build(name: category_name)
           category.save
+          # Cache the newly created category so later rows with the same
+          # name in this project reuse it instead of re-querying.
+          @category_by_project_and_name[[project.id, category_name]] = category
         end
 
         if category.blank? && fetch('standard_field-category', row).present?
@@ -522,6 +524,31 @@ class ImporterController < ApplicationController
       issue_cache: @issue_by_unique_attr,
       messages: @messages
     )
+
+    preload_reference_masters
+  end
+
+  # Bulk-load reference master records once and index them by name so the
+  # per-row lookups in #result don't fire an N+1 of find_by_* queries.
+  # Uses ||= to keep the first record per name, matching find_by_name's
+  # "first match" semantics (Enumeration is ordered by position via its
+  # default_scope; the others have effectively unique names).
+  def preload_reference_masters
+    @project_by_name = {}
+    Project.all.each { |p| @project_by_name[p.name] ||= p }
+
+    @tracker_by_name = {}
+    Tracker.all.each { |t| @tracker_by_name[t.name] ||= t }
+
+    @status_by_name = {}
+    IssueStatus.all.each { |s| @status_by_name[s.name] ||= s }
+
+    @priority_by_name = {}
+    Enumeration.all.each { |e| @priority_by_name[e.name] ||= e }
+
+    # Keyed by [project_id, name] to mirror find_by_project_id_and_name.
+    @category_by_project_and_name = {}
+    IssueCategory.all.each { |c| @category_by_project_and_name[[c.project_id, c.name]] ||= c }
   end
 
   def handle_watchers(issue, row, watchers)

--- a/pr_benchmark_section.md
+++ b/pr_benchmark_section.md
@@ -1,0 +1,40 @@
+## Performance: Eliminate N+1 queries for reference masters
+
+The per-row lookups of reference masters (Project / Tracker / IssueStatus /
+Enumeration / IssueCategory) in `ImporterController#result` — previously run for
+every CSV row via `find_by_name` / `find_by_project_id_and_name` — are now
+bulk-loaded once in `init_globals` and served from in-memory hashes, eliminating
+the N+1.
+
+### Benchmark
+
+- **Tables measured**: projects, trackers, issue_statuses, enumerations, issue_categories
+- **BEFORE** = per-row `find_by_*` (old code / N+1) — **AFTER** = bulk load + hash lookup
+- Query counts exclude cache hits and SCHEMA queries; measured with the AR query
+  cache disabled (`uncached`)
+- Environment: Redmine 6.0.5.stable / PostgreSQL
+
+| rows | before queries | after queries | queries reduced | before ms | after ms | time reduced |
+|-----:|---------------:|--------------:|----------------:|----------:|---------:|-------------:|
+|   50 |            250 |             5 |          -98.0% |      42.1 |      1.7 |       -95.9% |
+|  200 |           1000 |             5 |          -99.5% |     143.7 |      1.7 |       -98.8% |
+| 1000 |           5000 |             5 |          -99.9% |     617.8 |      2.1 |       -99.7% |
+
+- **before**: master queries grow linearly as `5 × N` (rows)
+- **after**: constant **5 queries** regardless of row count (one bulk load per table)
+- At 1000 rows: **5000 → 5 queries (-99.9%), 618ms → 2.1ms (-99.7%)**
+
+> Note: a real import saves an issue on every row, which invalidates the
+> ActiveRecord query cache each iteration. As a result the per-row `find_by_*`
+> calls are never served from cache and always hit the DB (a genuine N+1). The
+> benchmark therefore measures with the query cache disabled to stay faithful to
+> the real behavior.
+
+### How to reproduce
+
+Run from the Redmine root (with this plugin installed at `plugins/redmine_importer`):
+
+```bash
+RAILS_ENV=development bundle exec rails runner \
+  plugins/redmine_importer/test/benchmark/reference_master_lookup_benchmark.rb
+```

--- a/test/benchmark/reference_master_lookup_benchmark.rb
+++ b/test/benchmark/reference_master_lookup_benchmark.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+# Benchmark: N+1 elimination for reference-master lookups.
+#
+# The row loop in ImporterController#result used to look up reference masters
+# (Project / Tracker / IssueStatus / Enumeration / IssueCategory) by name on
+# every row. This script measures, against a real DB, the two approaches:
+#   BEFORE : per-row find_by_*        (= old code / N+1)
+#   AFTER  : bulk load + hash lookup  (= preload_reference_masters)
+# and prints a markdown table comparing before/after.
+#
+# Usage (run from the Redmine root with this plugin installed under plugins/):
+#   RAILS_ENV=development bundle exec rails runner \
+#     plugins/redmine_importer/test/benchmark/reference_master_lookup_benchmark.rb
+#
+# Measurement notes:
+# - Query counts come from ActiveSupport::Notifications('sql.active_record');
+#   cache hits (payload[:cached]) and SCHEMA queries are excluded.
+# - Measured deliberately inside connection.uncached. A real import saves an
+#   issue on every row, which invalidates the AR query cache each iteration, so
+#   the per-row find_by_* calls are never served from cache and always hit the
+#   DB (a genuine N+1). uncached stays faithful to that real behavior.
+
+MASTER_TABLES = %w[projects trackers issue_statuses enumerations issue_categories].freeze
+ROW_COUNTS = [50, 200, 1000].freeze
+
+# Run the block while counting non-cached queries against the 5 master tables.
+def measure(&block)
+  count = 0
+  subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |*args|
+    payload = args.last
+    next if payload[:cached]
+    next if payload[:name] == 'SCHEMA'
+
+    sql = payload[:sql].to_s
+    count += 1 if MASTER_TABLES.any? { |t| sql.match?(/\b#{t}\b/) }
+  end
+
+  started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  block.call
+  elapsed_ms = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000.0
+
+  [count, elapsed_ms]
+ensure
+  ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+end
+
+# Build N dummy rows. Each column cycles through existing master names.
+# (No Date.now / rand; values vary by index so results are reproducible.)
+def build_rows(n, names)
+  Array.new(n) do |i|
+    {
+      project: names[:project][i % names[:project].size],
+      tracker: names[:tracker][i % names[:tracker].size],
+      status: names[:status][i % names[:status].size],
+      priority: names[:priority][i % names[:priority].size],
+      category: names[:category][i % [names[:category].size, 1].max]
+    }
+  end
+end
+
+# BEFORE: the per-row find_by_* pattern, identical to the old code.
+def run_before(rows, project_id)
+  ActiveRecord::Base.connection.uncached do
+    rows.each do |row|
+      Project.find_by_name(row[:project])
+      Tracker.find_by_name(row[:tracker])
+      IssueStatus.find_by_name(row[:status])
+      Enumeration.find_by_name(row[:priority])
+      IssueCategory.find_by_project_id_and_name(project_id, row[:category])
+    end
+  end
+end
+
+# AFTER: bulk load + hash lookup, equivalent to preload_reference_masters.
+def run_after(rows, project_id)
+  ActiveRecord::Base.connection.uncached do
+    project_by_name = {}
+    Project.all.each { |p| project_by_name[p.name] ||= p }
+    tracker_by_name = {}
+    Tracker.all.each { |t| tracker_by_name[t.name] ||= t }
+    status_by_name = {}
+    IssueStatus.all.each { |s| status_by_name[s.name] ||= s }
+    priority_by_name = {}
+    Enumeration.all.each { |e| priority_by_name[e.name] ||= e }
+    category_by_project_and_name = {}
+    IssueCategory.all.each { |c| category_by_project_and_name[[c.project_id, c.name]] ||= c }
+
+    rows.each do |row|
+      project_by_name[row[:project]]
+      tracker_by_name[row[:tracker]]
+      status_by_name[row[:status]]
+      priority_by_name[row[:priority]]
+      category_by_project_and_name[[project_id, row[:category]]]
+    end
+  end
+end
+
+def pct(before, after)
+  return 'n/a' if before.zero?
+
+  format('%+.1f%%', (after - before) * 100.0 / before)
+end
+
+# --- Run ----------------------------------------------------------------
+
+names = {
+  project: Project.pluck(:name).compact,
+  tracker: Tracker.pluck(:name).compact,
+  status: IssueStatus.pluck(:name).compact,
+  priority: Enumeration.pluck(:name).compact,
+  category: IssueCategory.pluck(:name).compact
+}
+
+if names.values.any?(&:empty?)
+  warn 'Not enough master data. Run against a DB (e.g. development) that has ' \
+       'projects, trackers, statuses, priorities, and categories.'
+  exit 1
+end
+
+project_id = Project.first.id
+
+puts '## Reference-master N+1 elimination benchmark'
+puts
+puts "- Tables measured: #{MASTER_TABLES.join(', ')}"
+puts '- BEFORE = per-row find_by_* (old code / N+1) / AFTER = bulk load + hash lookup'
+puts '- Query counts exclude cache hits and SCHEMA; measured with AR query cache disabled (uncached)'
+puts "- Environment: Redmine #{Redmine::VERSION} / #{ActiveRecord::Base.connection.adapter_name} / #{Rails.env}"
+puts
+puts '| rows | before queries | after queries | queries reduced | before ms | after ms | time reduced |'
+puts '|-----:|---------------:|--------------:|----------------:|----------:|---------:|-------------:|'
+
+ROW_COUNTS.each do |n|
+  rows = build_rows(n, names)
+
+  # Warm-up (exclude one-time costs such as connection setup and class loading).
+  run_before(rows, project_id)
+  run_after(rows, project_id)
+
+  before_q, before_ms = measure { run_before(rows, project_id) }
+  after_q, after_ms = measure { run_after(rows, project_id) }
+
+  puts format('| %4d | %14d | %13d | %15s | %9.1f | %8.1f | %12s |',
+              n, before_q, after_q, pct(before_q, after_q),
+              before_ms, after_ms, pct(before_ms, after_ms))
+end
+
+puts
+puts 'Note: after keeps a constant 5 master queries regardless of N (one bulk load ' \
+     'per table), while before grows linearly as 5xN.'


### PR DESCRIPTION
## Performance: Eliminate N+1 queries for reference masters

The per-row lookups of reference masters (Project / Tracker / IssueStatus /
Enumeration / IssueCategory) in `ImporterController#result` — previously run for
every CSV row via `find_by_name` / `find_by_project_id_and_name` — are now
bulk-loaded once in `init_globals` and served from in-memory hashes, eliminating
the N+1.

### Benchmark

- **Tables measured**: projects, trackers, issue_statuses, enumerations, issue_categories
- **BEFORE** = per-row `find_by_*` (old code / N+1) — **AFTER** = bulk load + hash lookup
- Query counts exclude cache hits and SCHEMA queries; measured with the AR query
  cache disabled (`uncached`)
- Environment: Redmine 6.0.5.stable / PostgreSQL

| rows | before queries | after queries | queries reduced | before ms | after ms | time reduced |
|-----:|---------------:|--------------:|----------------:|----------:|---------:|-------------:|
|   50 |            250 |             5 |          -98.0% |      42.1 |      1.7 |       -95.9% |
|  200 |           1000 |             5 |          -99.5% |     143.7 |      1.7 |       -98.8% |
| 1000 |           5000 |             5 |          -99.9% |     617.8 |      2.1 |       -99.7% |

- **before**: master queries grow linearly as `5 × N` (rows)
- **after**: constant **5 queries** regardless of row count (one bulk load per table)
- At 1000 rows: **5000 → 5 queries (-99.9%), 618ms → 2.1ms (-99.7%)**

> Note: a real import saves an issue on every row, which invalidates the
> ActiveRecord query cache each iteration. As a result the per-row `find_by_*`
> calls are never served from cache and always hit the DB (a genuine N+1). The
> benchmark therefore measures with the query cache disabled to stay faithful to
> the real behavior.

### How to reproduce

Run from the Redmine root (with this plugin installed at `plugins/redmine_importer`):

```bash
RAILS_ENV=development bundle exec rails runner \
  plugins/redmine_importer/test/benchmark/reference_master_lookup_benchmark.rb
```
