### PR TITLE
Import in batches with polling to avoid server timeouts on large CSV files

### DIFF
--- a/app/controllers/importer_controller.rb
+++ b/app/controllers/importer_controller.rb
@@ -35,12 +35,12 @@ class ImporterController < ApplicationController
     end
 
     # Delete existing iip to ensure there can't be two iips for a user
-    ImportInProgress.where('user_id = ?', User.current.id).delete_all
-    # save import-in-progress data
-    iip = ImportInProgress.find_or_create_by(user_id: User.current.id)
-    # Remember the project the import was started on; run/result requests
-    # for any other project must not see or resume this import (#117121).
-    iip.project = @project
+    # within the same project; imports the user has in progress on other
+    # projects are independent and must not be discarded (#117121)
+    ImportInProgress.where(user_id: User.current.id, project_id: @project.id).delete_all
+    # save import-in-progress data, keyed by user and originating project;
+    # run/result requests for any other project must not see or resume it
+    iip = ImportInProgress.find_or_create_by(user_id: User.current.id, project_id: @project.id)
     iip.quote_char = params[:wrapper]
     iip.col_sep = params[:splitter]
     iip.encoding = params[:encoding]

--- a/app/controllers/importer_controller.rb
+++ b/app/controllers/importer_controller.rb
@@ -15,6 +15,12 @@ class ImporterController < ApplicationController
                    start_date due_date done_ratio estimated_hours
                    parent_issue watchers is_private].freeze
 
+  # Wall-clock budget of a single run request. Together with
+  # max_items_per_request this mirrors Redmine core's ImportsController#run,
+  # which processes at most 5 items / 10 seconds per request and lets the
+  # client drive the rest through repeated requests.
+  MAX_TIME_PER_REQUEST = 10.seconds
+
   def index; end
 
   def match
@@ -75,269 +81,25 @@ class ImporterController < ApplicationController
     @attrs.sort!
   end
 
+  # POST: validates the submitted mapping, persists it on the
+  # ImportInProgress record and redirects to the run page; the rows are then
+  # imported in batches driven by POST run requests.
+  # GET: renders the report of a finished import from the persisted state.
   def result
-    # used for bookkeeping
-    flash.delete(:error)
-
-    init_globals
-    # Used to optimize some work that has to happen inside the loop
-    unique_attr_checked = false
-
-    # Retrieve saved import data
-    iip = ImportInProgress.find_by_user_id(User.current.id)
-    if iip.nil?
-      flash[:error] = l(:error_no_import_in_progress)
-      return
+    if request.post?
+      prepare_import
+    else
+      show_result
     end
-    if iip.created.strftime('%Y-%m-%d %H:%M:%S') != params[:import_timestamp]
-      flash[:error] = l(:error_import_superseded)
-      return
-    end
-    # which options were turned on?
-    update_issue = params[:update_issue]
-    update_other_project = params[:update_other_project]
-    send_emails = params[:send_emails]
-    add_categories = params[:add_categories]
-    add_versions = params[:add_versions]
-    ignore_non_exist = params[:ignore_non_exist]
+  end
 
-    # which fields should we use? what maps to what?
-    unique_field = params[:unique_field].empty? ? nil : params[:unique_field]
-
-    fields_map = {}
-    params[:fields_map].each { |k, v| fields_map[k.unpack('U*').pack('U*')] = v }
-    unique_attr = fields_map[unique_field]
-
-    default_tracker = params[:default_tracker]
-    journal_field = params[:journal_field]
-
-    # attrs_map is fields_map's invert
-    @attrs_map = fields_map.invert
-
-    # validation!
-    # if the unique_attr is blank but any of the following opts is turned on,
-    if unique_attr.blank?
-      if update_issue
-        flash[:error] = l(:text_rmi_specify_unique_field_for_update)
-      elsif @attrs_map['standard_field-parent_issue'].present?
-        flash[:error] = l(:text_rmi_specify_unique_field_for_column,
-                          column: l(:field_parent_issue))
-      else IssueRelation::TYPES.each_key.any? { |t| @attrs_map["issue_relation-#{t}"].present? }
-           IssueRelation::TYPES.each_key do |t|
-             if @attrs_map["issue_relation-#{t}"].present?
-               flash[:error] = l(:text_rmi_specify_unique_field_for_column,
-                                 column: l("label_#{t}".to_sym))
-             end
-           end
-      end
-    end
-
-    # validate that the id attribute has been selected
-    if use_issue_id
-      if @attrs_map['standard_field-id'].blank?
-        flash[:error] = l(:error_must_map_id_column)
-      end
-    end
-
-    # if error is full, NOP
-    return if flash[:error].present?
-
-    csv_opt = { headers: true,
-                encoding: 'UTF-8',
-                quote_char: iip.quote_char,
-                col_sep: iip.col_sep }
-    CSV.new(iip.csv_data, **csv_opt).each do |row|
-      project = Project.find_by_name(fetch('standard_field-project', row))
-      project ||= @project
-
-      begin
-        row.each do |k, v|
-          k = k.unpack('U*').pack('U*') if k.is_a?(String)
-          v = v.unpack('U*').pack('U*') if v.is_a?(String)
-
-          row[k] = v
-        end
-
-        issue = Issue.new
-        issue.notify = false
-
-        issue.id = fetch('standard_field-id', row) if use_issue_id
-
-        tracker = Tracker.find_by_name(fetch('standard_field-tracker', row))
-        status = IssueStatus.find_by_name(fetch('standard_field-status', row))
-        author = if @attrs_map.key?('standard_field-author') && @attrs_map['standard_field-author']
-                   user_for_login!(fetch('standard_field-author', row))
-                 else
-                   User.current
-                 end
-        priority = Enumeration.find_by_name(fetch('standard_field-priority', row))
-        category_name = fetch('standard_field-category', row)
-        category = IssueCategory.find_by_project_id_and_name(project.id,
-                                                             category_name)
-
-        if !category \
-          && category_name && !category_name.empty? \
-          && add_categories
-
-          category = project.issue_categories.build(name: category_name)
-          category.save
-        end
-
-        if category.blank? && fetch('standard_field-category', row).present?
-          @unfound_class = 'Category'
-          @unfound_key = fetch('standard_field-category', row)
-          raise ActiveRecord::RecordNotFound
-        end
-
-        if fetch('standard_field-assigned_to', row).present?
-          assigned_to = user_for_login!(fetch('standard_field-assigned_to', row))
-          assigned_to = nil if assigned_to == User.anonymous
-        else
-          assigned_to = nil
-        end
-
-        if fetch('standard_field-fixed_version', row).present?
-          fixed_version_name = fetch('standard_field-fixed_version', row)
-          fixed_version_id = version_id_for_name!(project,
-                                                  fixed_version_name,
-                                                  add_versions)
-        else
-          fixed_version_name = nil
-          fixed_version_id = nil
-        end
-
-        watchers = fetch('standard_field-watchers', row)
-
-        issue.project_id = !project.nil? ? project.id : @project.id
-        issue.tracker_id = !tracker.nil? ? tracker.id : default_tracker
-        issue.author_id = !author.nil? ? author.id : User.current.id
-      rescue ActiveRecord::RecordNotFound
-        log_failure(row, l(:warning_record_not_found, issue_num: @failed_count + 1,
-                                                              class_name: @unfound_class, key: @unfound_key))
-        next
-      end
-
-      begin
-        unique_attr = translate_unique_attr(issue, unique_field, unique_attr, unique_attr_checked)
-
-        issue, journal = handle_issue_update(issue, row, author, status, update_other_project, journal_field,
-                                             unique_attr, unique_field, ignore_non_exist, update_issue)
-
-        project ||= Project.find_by_id(issue.project_id)
-
-        update_project_issues_stat(project)
-        assign_issue_attrs(issue, category, fixed_version_id, assigned_to, status, row, priority, tracker)
-        handle_parent_issues(issue, row, ignore_non_exist, unique_attr, unique_field)
-        handle_custom_fields(add_versions, issue, project, row)
-        handle_watchers(issue, row, watchers)
-      rescue RowFailed
-        next
-      rescue ActiveRecord::RecordNotFound
-        log_failure(row, l(:warning_record_not_found, issue_num: @failed_count + 1,
-                                                      class_name: @unfound_class, key: @unfound_key))
-        next
-      rescue ArgumentError
-        log_failure(row, l(:warning_invalid_value, issue_num: @failed_count + 1, value: @error_value))
-        next
-      end
-
-      issue.singleton_class.include RedmineImporter::Concerns::ValidateStatus
-
-      begin
-        issue_saved = issue.save
-      rescue ActiveRecord::RecordNotUnique
-        issue_saved = false
-        @messages << l(:error_issue_id_taken)
-      end
-
-      if issue_saved
-        @issue_by_unique_attr[row[unique_field]] = issue if unique_field
-        @deferred_callbacks.execute(row[unique_field], issue) if unique_field
-
-        if send_emails
-          if update_issue
-            if Setting.notified_events.include?('issue_updated') \
-               && !(issue.current_journal.details.empty? && issue.current_journal.notes.blank?)
-
-              Mailer.deliver_issue_edit(issue.current_journal)
-            end
-          else
-            if Setting.notified_events.include?('issue_added')
-              Mailer.deliver_issue_add(issue)
-            end
-          end
-        end
-
-        # Issue relations
-        IssueRelation::TYPES.each_pair do |rtype, _rinfo|
-          other_value = row[@attrs_map["issue_relation-#{rtype}"]]
-          next if other_value.blank?
-
-          begin
-            # When unique_attr is 'standard_field-id' and use_issue_id is false,
-            # use cache-based lookup to support deferred reference resolution.
-            if unique_attr == 'standard_field-id' && !use_issue_id
-              other_issue = @issue_by_unique_attr[other_value]
-              unless other_issue
-                # Target not in cache yet - register callback for deferred creation
-                @deferred_callbacks.register(other_value, :add_relation, row[unique_field], rtype)
-                next
-              end
-            else
-              other_issue = issue_for_unique_attr(unique_attr, other_value, row)
-            end
-
-            already_related = issue.relations.any? do |r|
-              (r.other_issue(issue).id == other_issue.id) \
-                && (r.relation_type_for(issue) == rtype)
-            end
-            next if already_related
-
-            relation = IssueRelation.new(issue_from: issue,
-                                         issue_to: other_issue,
-                                         relation_type: rtype)
-            unless relation.save
-              @messages << "Warning: Failed to create relation: #{relation.errors.full_messages.join(', ')}"
-            end
-          rescue NoIssueForUniqueValue
-            # Register callback for deferred relation creation
-            # Target issue may appear later in CSV
-            @deferred_callbacks.register(other_value, :add_relation, row[unique_field], rtype)
-          rescue MultipleIssuesForUniqueValue
-            @messages << "Warning: Multiple matches for relation target '#{other_value}'"
-          end
-        end
-
-        journal
-
-        @handle_count += 1
-
-      else
-        @failed_count += 1
-        @failed_issues[@failed_count] = row
-        @messages << l(:warning_validation_errors, issue_num: @failed_count)
-        issue.errors.each do |attr, error_message|
-          @messages << l(:warning_attr_error, attr: attr, message: error_message)
-        end
-      end
-    end # do
-
-    # Warn about any unresolved deferred references
-    @deferred_callbacks.warn_unresolved
-
-    unless @failed_issues.empty?
-      @failed_issues = @failed_issues.sort
-      @headers = @failed_issues[0][1].headers
-    end
-
-    # Clean up after ourselves
-    iip.delete
-
-    # Garbage prevention: clean up iips older than 3 days
-    ImportInProgress.where('created < ?', Time.new - 3 * 24 * 60 * 60).delete_all
-
-    if use_issue_id && ActiveRecord::Base.connection.respond_to?(:reset_pk_sequence!)
-      ActiveRecord::Base.connection.reset_pk_sequence!(Issue.table_name)
+  # GET: progress page. POST: imports one batch and responds with a redirect
+  # (html) or a self-recursive ajax snippet (js) until every row is consumed.
+  def run
+    if request.post?
+      process_batch
+    else
+      show_run_page
     end
   end
 
@@ -500,30 +262,6 @@ class ImporterController < ApplicationController
     raise RowFailed
   end
 
-  def init_globals
-    @handle_count = 0
-    @update_count = 0
-    @skip_count = 0
-    @failed_count = 0
-    @failed_issues = {}
-    @messages = []
-    @affect_projects_issues = {}
-    # This is a cache of previously inserted issues indexed by the value
-    # the user provided in the unique column
-    @issue_by_unique_attr = {}
-    # Cache of user id by login
-    @user_by_login = {}
-    # Cache of Version by name
-    @version_id_by_name = {}
-    # Cache of CustomFieldEnumeration by name
-    @enumeration_id_by_name = {}
-    # Deferred callbacks for resolving forward references in CSV
-    @deferred_callbacks = RedmineImporter::DeferredCallbacks.new(
-      issue_cache: @issue_by_unique_attr,
-      messages: @messages
-    )
-  end
-
   def handle_watchers(issue, row, watchers)
     return unless assignable?(:watchers)
 
@@ -599,8 +337,501 @@ class ImporterController < ApplicationController
 
   private
 
+  # POST result: everything the legacy single-request import did before its
+  # row loop — validations plus persisting the mapping so subsequent run
+  # requests can restore it.
+  def prepare_import
+    # used for bookkeeping
+    flash.delete(:error)
+
+    init_display_state
+
+    # Retrieve saved import data
+    iip = ImportInProgress.find_by_user_id(User.current.id)
+    if iip.nil?
+      flash[:error] = l(:error_no_import_in_progress)
+      return
+    end
+    if iip.created.strftime('%Y-%m-%d %H:%M:%S') != params[:import_timestamp]
+      flash[:error] = l(:error_import_superseded)
+      return
+    end
+    # A mapping form may only be submitted once per uploaded file (the legacy
+    # implementation guaranteed this by deleting the iip after importing);
+    # re-submitting would restart the import and duplicate issues.
+    if iip.settings.present?
+      flash[:error] = l(:error_import_superseded)
+      return
+    end
+
+    @import_params = extract_import_params
+    fields_map = @import_params['fields_map']
+    unique_field = @import_params['unique_field']
+    unique_attr = fields_map[unique_field]
+
+    # attrs_map is fields_map's invert
+    @attrs_map = fields_map.invert
+
+    # validation!
+    # if the unique_attr is blank but any of the following opts is turned on,
+    if unique_attr.blank?
+      if @import_params['update_issue']
+        flash[:error] = l(:text_rmi_specify_unique_field_for_update)
+      elsif @attrs_map['standard_field-parent_issue'].present?
+        flash[:error] = l(:text_rmi_specify_unique_field_for_column,
+                          column: l(:field_parent_issue))
+      else IssueRelation::TYPES.each_key.any? { |t| @attrs_map["issue_relation-#{t}"].present? }
+           IssueRelation::TYPES.each_key do |t|
+             if @attrs_map["issue_relation-#{t}"].present?
+               flash[:error] = l(:text_rmi_specify_unique_field_for_column,
+                                 column: l("label_#{t}".to_sym))
+             end
+           end
+      end
+    end
+
+    # validate that the id attribute has been selected
+    if use_issue_id
+      if @attrs_map['standard_field-id'].blank?
+        flash[:error] = l(:error_must_map_id_column)
+      end
+    end
+
+    # if error is full, NOP (renders the result template with the flash)
+    return if flash[:error].present?
+
+    total_items, headers = count_csv_rows(iip)
+
+    iip.import_settings = {
+      'params' => @import_params,
+      'headers' => headers,
+      'counts' => { 'handle_count' => 0, 'update_count' => 0,
+                    'skip_count' => 0, 'failed_count' => 0 },
+      'messages' => [],
+      'affect_projects_issues' => {},
+      'failed_rows' => [],
+      'issue_ids' => {},
+      'callbacks' => {}
+    }
+    iip.total_items = total_items
+    iip.position = 0
+    iip.finished = false
+    iip.save!
+
+    redirect_to project_importer_run_path(project_id: @project)
+  end
+
+  # GET run
+  def show_run_page
+    @iip = ImportInProgress.find_by_user_id(User.current.id)
+    if @iip.nil? || @iip.settings.blank?
+      flash[:error] = l(:error_no_import_in_progress)
+      redirect_to project_importer_path(project_id: @project)
+    elsif @iip.finished?
+      redirect_to project_importer_result_path(project_id: @project)
+    end
+  end
+
+  # POST run
+  def process_batch
+    @iip = ImportInProgress.find_by_user_id(User.current.id)
+    if @iip.nil? || @iip.settings.blank?
+      flash[:error] = l(:error_no_import_in_progress)
+      return redirect_to project_importer_path(project_id: @project)
+    end
+    return respond_after_batch if @iip.finished?
+
+    restore_import_state(@iip)
+    interrupted = run_batch(@iip)
+
+    unless interrupted
+      # Warn about any unresolved deferred references
+      @deferred_callbacks.warn_unresolved
+
+      if use_issue_id && ActiveRecord::Base.connection.respond_to?(:reset_pk_sequence!)
+        ActiveRecord::Base.connection.reset_pk_sequence!(Issue.table_name)
+      end
+    end
+
+    persist_import_state(@iip, finished: !interrupted)
+
+    # Garbage prevention: clean up iips older than 3 days
+    ImportInProgress.where('created < ?', Time.new - 3 * 24 * 60 * 60).delete_all
+
+    respond_after_batch
+  end
+
+  def respond_after_batch
+    respond_to do |format|
+      format.html do
+        if @iip.finished?
+          redirect_to project_importer_result_path(project_id: @project)
+        else
+          redirect_to project_importer_run_path(project_id: @project)
+        end
+      end
+      format.js # run.js.erb updates the progress bar and re-posts itself
+    end
+  end
+
+  # GET result
+  def show_result
+    init_display_state
+
+    iip = ImportInProgress.find_by_user_id(User.current.id)
+    if iip.nil? || iip.settings.blank?
+      flash.now[:error] = l(:error_no_import_in_progress)
+      return
+    end
+    return redirect_to project_importer_run_path(project_id: @project) unless iip.finished?
+
+    settings = iip.import_settings
+    counts = settings['counts'] || {}
+    @handle_count = counts['handle_count'].to_i
+    @update_count = counts['update_count'].to_i
+    @skip_count = counts['skip_count'].to_i
+    @failed_count = counts['failed_count'].to_i
+    @messages = settings['messages'] || []
+    @affect_projects_issues = settings['affect_projects_issues'] || {}
+    @headers = settings['headers'] || []
+    @failed_issues = (settings['failed_rows'] || [])
+                     .map { |index, fields| [index.to_i, CSV::Row.new(@headers, fields)] }
+                     .sort_by(&:first)
+  end
+
+  # Imports rows until the batch budget (max_items_per_request rows or
+  # MAX_TIME_PER_REQUEST) runs out. The CSV is re-parsed from the top on
+  # every request and rows up to iip.position are skipped, mirroring
+  # Redmine core's Import#run. Returns true when interrupted mid-file.
+  def run_batch(iip)
+    csv_opt = { headers: true,
+                encoding: 'UTF-8',
+                quote_char: iip.quote_char,
+                col_sep: iip.col_sep }
+    resume_after = iip.position
+    imported = 0
+    started_on = Time.now
+    interrupted = false
+    position = 0
+
+    CSV.new(iip.csv_data, **csv_opt).each do |row|
+      position += 1
+      next if position <= resume_after
+
+      if imported >= max_items_per_request || Time.now >= started_on + MAX_TIME_PER_REQUEST
+        interrupted = true
+        break
+      end
+
+      import_row(row)
+      imported += 1
+      iip.position = position
+    end
+
+    interrupted
+  end
+
+  # One row of the legacy import loop, unchanged apart from reading the
+  # import options from the persisted settings and returning (instead of
+  # `next`) when the row fails.
+  def import_row(row)
+    update_issue = import_param('update_issue')
+    update_other_project = import_param('update_other_project')
+    send_emails = import_param('send_emails')
+    add_categories = import_param('add_categories')
+    add_versions = import_param('add_versions')
+    ignore_non_exist = import_param('ignore_non_exist')
+    unique_field = import_param('unique_field')
+    default_tracker = import_param('default_tracker')
+    journal_field = import_param('journal_field')
+
+    project = Project.find_by_name(fetch('standard_field-project', row))
+    project ||= @project
+
+    begin
+      row.each do |k, v|
+        k = k.unpack('U*').pack('U*') if k.is_a?(String)
+        v = v.unpack('U*').pack('U*') if v.is_a?(String)
+
+        row[k] = v
+      end
+
+      issue = Issue.new
+      issue.notify = false
+
+      issue.id = fetch('standard_field-id', row) if use_issue_id
+
+      tracker = Tracker.find_by_name(fetch('standard_field-tracker', row))
+      status = IssueStatus.find_by_name(fetch('standard_field-status', row))
+      author = if @attrs_map.key?('standard_field-author') && @attrs_map['standard_field-author']
+                 user_for_login!(fetch('standard_field-author', row))
+               else
+                 User.current
+               end
+      priority = Enumeration.find_by_name(fetch('standard_field-priority', row))
+      category_name = fetch('standard_field-category', row)
+      category = IssueCategory.find_by_project_id_and_name(project.id,
+                                                           category_name)
+
+      if !category \
+        && category_name && !category_name.empty? \
+        && add_categories
+
+        category = project.issue_categories.build(name: category_name)
+        category.save
+      end
+
+      if category.blank? && fetch('standard_field-category', row).present?
+        @unfound_class = 'Category'
+        @unfound_key = fetch('standard_field-category', row)
+        raise ActiveRecord::RecordNotFound
+      end
+
+      if fetch('standard_field-assigned_to', row).present?
+        assigned_to = user_for_login!(fetch('standard_field-assigned_to', row))
+        assigned_to = nil if assigned_to == User.anonymous
+      else
+        assigned_to = nil
+      end
+
+      if fetch('standard_field-fixed_version', row).present?
+        fixed_version_name = fetch('standard_field-fixed_version', row)
+        fixed_version_id = version_id_for_name!(project,
+                                                fixed_version_name,
+                                                add_versions)
+      else
+        fixed_version_name = nil
+        fixed_version_id = nil
+      end
+
+      watchers = fetch('standard_field-watchers', row)
+
+      issue.project_id = !project.nil? ? project.id : @project.id
+      issue.tracker_id = !tracker.nil? ? tracker.id : default_tracker
+      issue.author_id = !author.nil? ? author.id : User.current.id
+    rescue ActiveRecord::RecordNotFound
+      log_failure(row, l(:warning_record_not_found, issue_num: @failed_count + 1,
+                                                            class_name: @unfound_class, key: @unfound_key))
+      return
+    end
+
+    begin
+      @unique_attr = translate_unique_attr(issue, unique_field, @unique_attr, @unique_attr_checked)
+      @unique_attr_checked = true
+
+      issue, journal = handle_issue_update(issue, row, author, status, update_other_project, journal_field,
+                                           @unique_attr, unique_field, ignore_non_exist, update_issue)
+
+      project ||= Project.find_by_id(issue.project_id)
+
+      update_project_issues_stat(project)
+      assign_issue_attrs(issue, category, fixed_version_id, assigned_to, status, row, priority, tracker)
+      handle_parent_issues(issue, row, ignore_non_exist, @unique_attr, unique_field)
+      handle_custom_fields(add_versions, issue, project, row)
+      handle_watchers(issue, row, watchers)
+    rescue RowFailed
+      return
+    rescue ActiveRecord::RecordNotFound
+      log_failure(row, l(:warning_record_not_found, issue_num: @failed_count + 1,
+                                                    class_name: @unfound_class, key: @unfound_key))
+      return
+    rescue ArgumentError
+      log_failure(row, l(:warning_invalid_value, issue_num: @failed_count + 1, value: @error_value))
+      return
+    end
+
+    issue.singleton_class.include RedmineImporter::Concerns::ValidateStatus
+
+    begin
+      issue_saved = issue.save
+    rescue ActiveRecord::RecordNotUnique
+      issue_saved = false
+      @messages << l(:error_issue_id_taken)
+    end
+
+    if issue_saved
+      @issue_by_unique_attr[row[unique_field]] = issue if unique_field
+      @deferred_callbacks.execute(row[unique_field], issue) if unique_field
+
+      if send_emails
+        if update_issue
+          if Setting.notified_events.include?('issue_updated') \
+             && !(issue.current_journal.details.empty? && issue.current_journal.notes.blank?)
+
+            Mailer.deliver_issue_edit(issue.current_journal)
+          end
+        else
+          if Setting.notified_events.include?('issue_added')
+            Mailer.deliver_issue_add(issue)
+          end
+        end
+      end
+
+      # Issue relations
+      IssueRelation::TYPES.each_pair do |rtype, _rinfo|
+        other_value = row[@attrs_map["issue_relation-#{rtype}"]]
+        next if other_value.blank?
+
+        begin
+          # When unique_attr is 'standard_field-id' and use_issue_id is false,
+          # use cache-based lookup to support deferred reference resolution.
+          if @unique_attr == 'standard_field-id' && !use_issue_id
+            other_issue = @issue_by_unique_attr[other_value]
+            unless other_issue
+              # Target not in cache yet - register callback for deferred creation
+              @deferred_callbacks.register(other_value, :add_relation, row[unique_field], rtype)
+              next
+            end
+          else
+            other_issue = issue_for_unique_attr(@unique_attr, other_value, row)
+          end
+
+          already_related = issue.relations.any? do |r|
+            (r.other_issue(issue).id == other_issue.id) \
+              && (r.relation_type_for(issue) == rtype)
+          end
+          next if already_related
+
+          relation = IssueRelation.new(issue_from: issue,
+                                       issue_to: other_issue,
+                                       relation_type: rtype)
+          unless relation.save
+            @messages << "Warning: Failed to create relation: #{relation.errors.full_messages.join(', ')}"
+          end
+        rescue NoIssueForUniqueValue
+          # Register callback for deferred relation creation
+          # Target issue may appear later in CSV
+          @deferred_callbacks.register(other_value, :add_relation, row[unique_field], rtype)
+        rescue MultipleIssuesForUniqueValue
+          @messages << "Warning: Multiple matches for relation target '#{other_value}'"
+        end
+      end
+
+      journal
+
+      @handle_count += 1
+
+    else
+      @failed_count += 1
+      @failed_issues[@failed_count] = row
+      @messages << l(:warning_validation_errors, issue_num: @failed_count)
+      issue.errors.each do |attr, error_message|
+        @messages << l(:warning_attr_error, attr: attr, message: error_message)
+      end
+    end
+  end
+
+  # Import options captured from the mapping form, in a JSON-serializable
+  # shape so run requests can restore them from the ImportInProgress record.
+  def extract_import_params
+    fields_map = {}
+    params[:fields_map].each { |k, v| fields_map[k.unpack('U*').pack('U*')] = v }
+
+    {
+      'fields_map' => fields_map,
+      'unique_field' => params[:unique_field].present? ? params[:unique_field] : nil,
+      'update_issue' => params[:update_issue],
+      'update_other_project' => params[:update_other_project],
+      'send_emails' => params[:send_emails],
+      'add_categories' => params[:add_categories],
+      'add_versions' => params[:add_versions],
+      'ignore_non_exist' => params[:ignore_non_exist],
+      'use_anonymous' => params[:use_anonymous],
+      'use_issue_id' => params[:use_issue_id],
+      'default_tracker' => params[:default_tracker],
+      'journal_field' => params[:journal_field]
+    }
+  end
+
+  def import_param(key)
+    (@import_params || {})[key]
+  end
+
+  def restore_import_state(iip)
+    settings = iip.import_settings
+    @import_params = settings['params'] || {}
+    fields_map = @import_params['fields_map'] || {}
+    @attrs_map = fields_map.invert
+    @unique_attr = fields_map[@import_params['unique_field']]
+    @unique_attr_checked = false
+
+    counts = settings['counts'] || {}
+    @handle_count = counts['handle_count'].to_i
+    @update_count = counts['update_count'].to_i
+    @skip_count = counts['skip_count'].to_i
+    @failed_count = counts['failed_count'].to_i
+    @messages = settings['messages'] || []
+    @affect_projects_issues = settings['affect_projects_issues'] || {}
+    @csv_headers = settings['headers'] || []
+    @failed_issues = (settings['failed_rows'] || []).each_with_object({}) do |(index, fields), h|
+      h[index.to_i] = CSV::Row.new(@csv_headers, fields)
+    end
+
+    # This is a cache of previously inserted issues indexed by the value
+    # the user provided in the unique column
+    @issue_by_unique_attr = RedmineImporter::IssueUniqueCache.new(settings['issue_ids'])
+    # Cache of user id by login
+    @user_by_login = {}
+    # Cache of Version by name
+    @version_id_by_name = {}
+    # Cache of CustomFieldEnumeration by name
+    @enumeration_id_by_name = {}
+    # Deferred callbacks for resolving forward references in CSV
+    @deferred_callbacks = RedmineImporter::DeferredCallbacks.new(
+      issue_cache: @issue_by_unique_attr,
+      messages: @messages,
+      pending: settings['callbacks'] || {}
+    )
+  end
+
+  def persist_import_state(iip, finished:)
+    settings = iip.import_settings
+    settings['counts'] = { 'handle_count' => @handle_count,
+                           'update_count' => @update_count,
+                           'skip_count' => @skip_count,
+                           'failed_count' => @failed_count }
+    settings['messages'] = @messages
+    settings['affect_projects_issues'] = @affect_projects_issues
+    settings['failed_rows'] = @failed_issues.map { |index, row| [index, row.fields] }
+    settings['issue_ids'] = @issue_by_unique_attr.ids
+    settings['callbacks'] = @deferred_callbacks.pending
+    iip.import_settings = settings
+    iip.finished = finished
+    iip.save!
+  end
+
+  def init_display_state
+    @handle_count = 0
+    @update_count = 0
+    @skip_count = 0
+    @failed_count = 0
+    @failed_issues = {}
+    @messages = []
+    @affect_projects_issues = {}
+    @headers = []
+  end
+
+  def count_csv_rows(iip)
+    count = 0
+    headers = []
+    CSV.new(iip.csv_data, headers: true,
+                          encoding: 'UTF-8',
+                          quote_char: iip.quote_char,
+                          col_sep: iip.col_sep).each do |row|
+      headers = row.headers if count.zero?
+      count += 1
+    end
+    [count, headers]
+  end
+
+  # Rows imported per run request. Kept as a method (not a constant) so
+  # tests can stub it, like Redmine core's ImportsController.
+  def max_items_per_request
+    5
+  end
+
   def use_issue_id
-    params[:use_issue_id].present?
+    import_param('use_issue_id').present?
   end
 
   def fetch(key, row)
@@ -785,7 +1016,7 @@ class ImporterController < ApplicationController
 
       @user_by_login[login] = user
     rescue ActiveRecord::RecordNotFound
-      if params[:use_anonymous]
+      if import_param('use_anonymous')
         @user_by_login[login] = User.anonymous
       else
         @unfound_class = 'User'

--- a/app/controllers/importer_controller.rb
+++ b/app/controllers/importer_controller.rb
@@ -374,6 +374,7 @@ class ImporterController < ApplicationController
     # once it finished (#117120).
     if iip.settings.present?
       if iip.finished?
+        flash[:notice] = l(:notice_import_already_finished)
         redirect_to project_importer_result_path(project_id: @project)
       else
         flash[:notice] = l(:notice_import_already_running)

--- a/app/controllers/importer_controller.rb
+++ b/app/controllers/importer_controller.rb
@@ -9,6 +9,10 @@ NoIssueForUniqueValue = Class.new(RuntimeError)
 class ImporterController < ApplicationController
   using RedmineImporter::Patches::Redmine51ToFsMethodPatch
   before_action :find_project
+  # Every action requires the :import permission on the URL's project (the
+  # importer module must be enabled there and the role must allow it), like
+  # Redmine core's project-scoped controllers.
+  before_action :authorize
 
   ISSUE_ATTRS = %i[id subject assigned_to fixed_version
                    author description category priority tracker status
@@ -34,6 +38,9 @@ class ImporterController < ApplicationController
     ImportInProgress.where('user_id = ?', User.current.id).delete_all
     # save import-in-progress data
     iip = ImportInProgress.find_or_create_by(user_id: User.current.id)
+    # Remember the project the import was started on; run/result requests
+    # for any other project must not see or resume this import (#117121).
+    iip.project = @project
     iip.quote_char = params[:wrapper]
     iip.col_sep = params[:splitter]
     iip.encoding = params[:encoding]
@@ -347,7 +354,7 @@ class ImporterController < ApplicationController
     init_display_state
 
     # Retrieve saved import data
-    iip = ImportInProgress.find_by_user_id(User.current.id)
+    iip = current_import_in_progress
     if iip.nil?
       flash[:error] = l(:error_no_import_in_progress)
       return
@@ -423,7 +430,7 @@ class ImporterController < ApplicationController
 
   # GET run
   def show_run_page
-    @iip = ImportInProgress.find_by_user_id(User.current.id)
+    @iip = current_import_in_progress
     if @iip.nil? || @iip.settings.blank?
       flash[:error] = l(:error_no_import_in_progress)
       redirect_to project_importer_path(project_id: @project)
@@ -434,7 +441,7 @@ class ImporterController < ApplicationController
 
   # POST run
   def process_batch
-    @iip = ImportInProgress.find_by_user_id(User.current.id)
+    @iip = current_import_in_progress
     if @iip.nil? || @iip.settings.blank?
       flash[:error] = l(:error_no_import_in_progress)
       return redirect_to project_importer_path(project_id: @project)
@@ -490,7 +497,7 @@ class ImporterController < ApplicationController
   def show_result
     init_display_state
 
-    iip = ImportInProgress.find_by_user_id(User.current.id)
+    iip = current_import_in_progress
     if iip.nil? || iip.settings.blank?
       flash.now[:error] = l(:error_no_import_in_progress)
       return
@@ -861,6 +868,16 @@ class ImporterController < ApplicationController
 
   def find_project
     @project = Project.find(params[:project_id])
+  end
+
+  # The import the current user started on the current project. Scoping by
+  # project (in addition to user) makes an import invisible from any other
+  # project's URL: the batch target project is derived from the URL, so a
+  # stale tab on a foreign project would otherwise import the remaining rows
+  # into that unrelated project (#117121). A mismatch behaves exactly like
+  # "no import in progress".
+  def current_import_in_progress
+    ImportInProgress.find_by(user_id: User.current.id, project_id: @project.id)
   end
 
   def flash_message(type, text)

--- a/app/controllers/importer_controller.rb
+++ b/app/controllers/importer_controller.rb
@@ -365,9 +365,20 @@ class ImporterController < ApplicationController
     end
     # A mapping form may only be submitted once per uploaded file (the legacy
     # implementation guaranteed this by deleting the iip after importing);
-    # re-submitting would restart the import and duplicate issues.
+    # re-submitting would restart the import and duplicate issues. The
+    # timestamp matched above, so this is the form of the import the user
+    # already started (typically the browser's back button from the progress
+    # page): send them back to that import instead of failing with the
+    # misleading "superseded" error — to the progress page while it is
+    # running, so polling resumes from the saved position, or to its report
+    # once it finished (#117120).
     if iip.settings.present?
-      flash[:error] = l(:error_import_superseded)
+      if iip.finished?
+        redirect_to project_importer_result_path(project_id: @project)
+      else
+        flash[:notice] = l(:notice_import_already_running)
+        redirect_to project_importer_run_path(project_id: @project)
+      end
       return
     end
 

--- a/app/controllers/importer_controller.rb
+++ b/app/controllers/importer_controller.rb
@@ -439,24 +439,36 @@ class ImporterController < ApplicationController
       flash[:error] = l(:error_no_import_in_progress)
       return redirect_to project_importer_path(project_id: @project)
     end
-    return respond_after_batch if @iip.finished?
+    # Serialize concurrent run requests (a reloaded progress page or a second
+    # tab starts another polling chain): the row lock blocks the concurrent
+    # request until this batch commits, so it re-reads the advanced position
+    # and continues with the following rows instead of re-importing the same
+    # ones. The lock's transaction also makes the batch atomic — when a row
+    # fails with an unexpected error the whole batch rolls back, so a retry
+    # never duplicates issues.
+    @iip.with_lock do
+      unless @iip.finished?
+        restore_import_state(@iip)
+        interrupted = run_batch(@iip)
 
-    restore_import_state(@iip)
-    interrupted = run_batch(@iip)
+        unless interrupted
+          # Warn about any unresolved deferred references
+          @deferred_callbacks.warn_unresolved
 
-    unless interrupted
-      # Warn about any unresolved deferred references
-      @deferred_callbacks.warn_unresolved
+          if use_issue_id && ActiveRecord::Base.connection.respond_to?(:reset_pk_sequence!)
+            ActiveRecord::Base.connection.reset_pk_sequence!(Issue.table_name)
+          end
 
-      if use_issue_id && ActiveRecord::Base.connection.respond_to?(:reset_pk_sequence!)
-        ActiveRecord::Base.connection.reset_pk_sequence!(Issue.table_name)
+          # Garbage prevention: clean up imports abandoned for more than
+          # 3 days — only when an import finishes (not on the hot polling
+          # path), and never the import that just finished
+          ImportInProgress.where('created < ?', Time.new - 3 * 24 * 60 * 60)
+                          .where.not(id: @iip.id).delete_all
+        end
+
+        persist_import_state(@iip, finished: !interrupted)
       end
     end
-
-    persist_import_state(@iip, finished: !interrupted)
-
-    # Garbage prevention: clean up iips older than 3 days
-    ImportInProgress.where('created < ?', Time.new - 3 * 24 * 60 * 60).delete_all
 
     respond_after_batch
   end
@@ -643,7 +655,10 @@ class ImporterController < ApplicationController
     issue.singleton_class.include RedmineImporter::Concerns::ValidateStatus
 
     begin
-      issue_saved = issue.save
+      # The savepoint keeps the surrounding batch transaction usable when the
+      # INSERT itself fails (e.g. on the primary key with use_issue_id) —
+      # PostgreSQL aborts the whole transaction on any SQL error otherwise.
+      issue_saved = Issue.transaction(requires_new: true) { issue.save }
     rescue ActiveRecord::RecordNotUnique
       issue_saved = false
       @messages << l(:error_issue_id_taken)
@@ -958,7 +973,14 @@ class ImporterController < ApplicationController
   # Raises NoIssueForUniqueValue if not found or MultipleIssuesForUniqueValue
   def issue_for_unique_attr(unique_attr, attr_value, row_data)
     if @issue_by_unique_attr.key?(attr_value)
-      return @issue_by_unique_attr[attr_value]
+      cached = @issue_by_unique_attr[attr_value]
+      # The cache is authoritative for values this import created: a nil hit
+      # means the issue was deleted after an earlier batch imported it, so
+      # treat it as not found and let the row fail gracefully instead of
+      # crashing the whole batch request.
+      return cached if cached
+
+      raise NoIssueForUniqueValue, "Issue with #{unique_attr} of '#{attr_value}' was deleted"
     end
 
     if use_issue_id && unique_attr == 'standard_field-id'

--- a/app/models/import_in_progress.rb
+++ b/app/models/import_in_progress.rb
@@ -5,9 +5,26 @@ class ImportInProgress < ActiveRecord::Base
 
   before_save :encode_csv_data
 
+  # Batch-import state persisted between run requests, stored as JSON in the
+  # `settings` text column (mirrors Redmine core's Import#settings).
+  def import_settings
+    @import_settings ||= settings.blank? ? {} : JSON.parse(settings)
+  end
+
+  def import_settings=(hash)
+    @import_settings = hash
+    self.settings = JSON.generate(hash)
+  end
+
+  def save_import_settings!
+    self.settings = JSON.generate(import_settings)
+    save!
+  end
+
   private
   def encode_csv_data
     return if self.csv_data.blank?
+    return unless will_save_change_to_csv_data?
 
     self.csv_data = self.csv_data
     # 入力文字コード

--- a/app/views/importer/run.html.erb
+++ b/app/views/importer/run.html.erb
@@ -1,0 +1,20 @@
+<% content_for :header_tags do %>
+  <%= stylesheet_link_tag 'importer', :plugin => 'redmine_importer' %>
+<% end %>
+
+<h2><%= l(:label_importer_progress) %></h2>
+
+<div id="import-details">
+  <div id="import-progress"><div id="progress-label"><%= @iip.position %> / <%= @iip.total_items.to_i %></div></div>
+</div>
+
+<%= javascript_tag do %>
+$(document).ready(function() {
+  $('#import-details').addClass('ajax-loading');
+  $('#import-progress').progressbar({value: <%= @iip.position %>, max: <%= @iip.total_items.to_i %>});
+  $.ajax({
+    url: '<%= project_importer_run_path(project_id: @project, format: 'js') %>',
+    type: 'post'
+  });
+});
+<% end %>

--- a/app/views/importer/run.js.erb
+++ b/app/views/importer/run.js.erb
@@ -1,0 +1,11 @@
+$('#import-progress').progressbar({value: <%= @iip.position %>});
+$('#progress-label').text("<%= @iip.position %> / <%= @iip.total_items.to_i %>");
+
+<% if @iip.finished? %>
+window.location.href='<%= project_importer_result_path(project_id: @project) %>';
+<% else %>
+$.ajax({
+  url: '<%= project_importer_run_path(project_id: @project, format: 'js') %>',
+  type: 'post'
+});
+<% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -25,6 +25,7 @@ de:
     label_rule_name: "Name der Input-Regel"
     
     label_import_result: "Import Ergebnis"
+    label_importer_progress: "Import läuft..."
     label_result_notice: "%{handle_count} Tickets verarbeitet.  {{success_count}} Tickets erfolgreich importiert."
     label_result_projects: "Betroffene Projekte:"
     label_result_issues: "%{count} Tickets"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -43,6 +43,7 @@ de:
     label_importer_use_issue_id: "Import using issue ids"
     error_no_import_in_progress: "No import is currently in progress"
     error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
+    notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
     error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
     error_issue_id_taken: "This issue id has already been taken."
     error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -44,6 +44,7 @@ de:
     error_no_import_in_progress: "No import is currently in progress"
     error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
     notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
+    notice_import_already_finished: "The import you submitted has already finished, so its report is shown. No rows were imported again."
     error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
     error_issue_id_taken: "This issue id has already been taken."
     error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,7 @@ en:
 
   error_no_import_in_progress: "No import is currently in progress"
   error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
+  notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
   error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
   error_issue_id_taken: "This issue id has already been taken."
   error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,7 @@ en:
   label_rule_name: "Input rule name"
 
   label_import_result: "Import Result"
+  label_importer_progress: "Import in progress..."
   label_result_notice: "%{handle_count} issues processed.  %{success_count} issues successfully imported."
   label_result_projects: "Affected projects:"
   label_result_issues: "%{count} issues"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,6 +52,7 @@ en:
   error_no_import_in_progress: "No import is currently in progress"
   error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
   notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
+  notice_import_already_finished: "The import you submitted has already finished, so its report is shown. No rows were imported again."
   error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
   error_issue_id_taken: "This issue id has already been taken."
   error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -53,6 +53,7 @@ ja:
   error_no_import_in_progress: "現在進行中のインポートがありません。"
   error_import_superseded: "このインポートは別のインポートにより無効になりました。"
   notice_import_already_running: "実行中のインポートがあるため進捗画面を表示しています。残りの行は引き続き取り込まれます。"
+  notice_import_already_finished: "送信されたインポートは既に完了しているため、結果画面を表示しています。行が再度取り込まれることはありません。"
   error_must_map_id_column: "チケットIDを使用してインポートする場合、対応するIDの列を指定してください。"
   error_issue_id_taken: "このチケットIDは既に使用されています。"
   error_csv_no_data: "CSVにデータ行がありません。ファイルのエンコーディングを確認してください。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -26,6 +26,7 @@ ja:
   label_rule_name: "ルール名を入力:"
 
   label_import_result: "インポート結果"
+  label_importer_progress: "インポート実行中..."
   label_result_notice: "%{handle_count} 行が処理されました。%{success_count} 行が正しく追加されました。"
   label_result_projects: "対象となったプロジェクト:"
   label_result_issues: "%{count} 行"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -52,6 +52,7 @@ ja:
 
   error_no_import_in_progress: "現在進行中のインポートがありません。"
   error_import_superseded: "このインポートは別のインポートにより無効になりました。"
+  notice_import_already_running: "実行中のインポートがあるため進捗画面を表示しています。残りの行は引き続き取り込まれます。"
   error_must_map_id_column: "チケットIDを使用してインポートする場合、対応するIDの列を指定してください。"
   error_issue_id_taken: "このチケットIDは既に使用されています。"
   error_csv_no_data: "CSVにデータ行がありません。ファイルのエンコーディングを確認してください。"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -41,6 +41,7 @@ pt-BR:
   error_no_import_in_progress: "No import is currently in progress"
   error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
   notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
+  notice_import_already_finished: "The import you submitted has already finished, so its report is shown. No rows were imported again."
   error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
   error_issue_id_taken: "This issue id has already been taken."
   error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -40,6 +40,7 @@ pt-BR:
   label_importer_use_issue_id: "Import using issue ids"
   error_no_import_in_progress: "No import is currently in progress"
   error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
+  notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
   error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
   error_issue_id_taken: "This issue id has already been taken."
   error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -25,6 +25,7 @@ pt-BR:
   label_rule_name: "Entre com o nome da regra"
   
   label_import_result: "Resultado da Importação"
+  label_importer_progress: "Importação em andamento..."
   label_result_notice: "{{handle_count}} tarefas processadas.  {{success_count}} tarefas importadas com sucesso."
   label_result_projects: "Projetos afetados:"
   label_result_issues: "{{count}} tarefas"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -43,6 +43,7 @@ ru:
   label_importer_use_issue_id: "Import using issue ids"
   error_no_import_in_progress: "No import is currently in progress"
   error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
+  notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
   error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
   error_issue_id_taken: "This issue id has already been taken."
   error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -25,6 +25,7 @@ ru:
   label_rule_name: "Input rule name"
 
   label_import_result: "Результат импорта"
+  label_importer_progress: "Выполняется импорт..."
   label_result_notice: "%{handle_count} задач(а) обработано.  %{success_count} задач(а) была успешно импортирована."
   label_result_projects: "Затронуто проектов:"
   label_result_issues: "%{count} задач(а)"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -44,6 +44,7 @@ ru:
   error_no_import_in_progress: "No import is currently in progress"
   error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
   notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
+  notice_import_already_finished: "The import you submitted has already finished, so its report is shown. No rows were imported again."
   error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
   error_issue_id_taken: "This issue id has already been taken."
   error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -44,6 +44,7 @@ zh:
   label_importer_use_issue_id: "Import using issue ids"
   error_no_import_in_progress: "No import is currently in progress"
   error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
+  notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
   error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
   error_issue_id_taken: "This issue id has already been taken."
   error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -26,6 +26,7 @@ zh:
   label_rule_name: "输入规则名称"
  
   label_import_result: "导入结果"
+  label_importer_progress: "正在导入..."
   label_result_notice: "处理了{{handle_count}}个问题。{{success_count}}个问题被成功导入。"
   label_result_projects: "受影响的项目:"
   label_result_issues: "{{count}} 个问题"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -45,6 +45,7 @@ zh:
   error_no_import_in_progress: "No import is currently in progress"
   error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
   notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
+  notice_import_already_finished: "The import you submitted has already finished, so its report is shown. No rows were imported again."
   error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
   error_issue_id_taken: "This issue id has already been taken."
   error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,6 @@ resources :projects do
   post '/importer/match', to: 'importer#match'
   get '/importer/result', to: 'importer#result'
   post '/importer/result', to: 'importer#result'
+  get '/importer/run', to: 'importer#run'
+  post '/importer/run', to: 'importer#run'
 end

--- a/db/migrate/002_add_batch_state_to_import_in_progresses.rb
+++ b/db/migrate/002_add_batch_state_to_import_in_progresses.rb
@@ -2,7 +2,12 @@
 
 class AddBatchStateToImportInProgresses < ActiveRecord::Migration[6.1]
   def change
-    add_column :import_in_progresses, :settings, :text
+    # The per-row state stored in settings grows with the CSV size and
+    # exceeds MySQL's 64 KB TEXT at roughly 4-5k rows. 1 GB - 1 is the
+    # largest limit accepted by both adapters: MySQL maps any limit above
+    # 16 MB to LONGTEXT, and PostgreSQL (where text is unbounded anyway)
+    # raises on limits above 1 GB - 1.
+    add_column :import_in_progresses, :settings, :text, limit: 1_073_741_823
     add_column :import_in_progresses, :total_items, :integer
     add_column :import_in_progresses, :position, :integer, default: 0, null: false
     add_column :import_in_progresses, :finished, :boolean, default: false, null: false

--- a/db/migrate/002_add_batch_state_to_import_in_progresses.rb
+++ b/db/migrate/002_add_batch_state_to_import_in_progresses.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddBatchStateToImportInProgresses < ActiveRecord::Migration[6.1]
+  def change
+    add_column :import_in_progresses, :settings, :text
+    add_column :import_in_progresses, :total_items, :integer
+    add_column :import_in_progresses, :position, :integer, default: 0, null: false
+    add_column :import_in_progresses, :finished, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/003_add_project_to_import_in_progresses.rb
+++ b/db/migrate/003_add_project_to_import_in_progresses.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddProjectToImportInProgresses < ActiveRecord::Migration[6.1]
+  def change
+    # The project the import was started on. run/result requests whose URL
+    # points at a different project are rejected, so a stale tab cannot
+    # import the remaining rows into an unrelated project (#117121).
+    add_column :import_in_progresses, :project_id, :integer
+  end
+end

--- a/init.rb
+++ b/init.rb
@@ -17,7 +17,9 @@ Redmine::Plugin.register :redmine_importer do
            partial: 'settings/redmine_importer_settings'
 
   project_module :importer do
-    permission :import, importer: :index
+    # Every action must be declared here so that ImporterController's
+    # `authorize` filter can also protect the result/run pages (#117121).
+    permission :import, importer: %i[index match result run]
   end
   menu :project_menu,
        :importer,

--- a/lib/redmine_importer/deferred_callbacks.rb
+++ b/lib/redmine_importer/deferred_callbacks.rb
@@ -5,11 +5,18 @@ module RedmineImporter
   # that haven't been imported yet (e.g., parent issues or relations
   # defined later in the CSV file).
   class DeferredCallbacks
-    def initialize(issue_cache:, messages:)
-      @pending = {}
+    # `pending` accepts previously persisted callbacks so unresolved forward
+    # references survive across batched import requests
+    # (ImportInProgress#import_settings round-trips them through JSON,
+    # turning callback-name symbols into strings — `execute` handles both).
+    def initialize(issue_cache:, messages:, pending: {})
+      @pending = pending || {}
       @issue_cache = issue_cache
       @messages = messages
     end
+
+    # Unresolved callbacks, in a JSON-serializable form.
+    attr_reader :pending
 
     # Registers a callback to be executed when an issue with the given
     # unique_value is imported.

--- a/lib/redmine_importer/issue_unique_cache.rb
+++ b/lib/redmine_importer/issue_unique_cache.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module RedmineImporter
+  # Cache of imported issues indexed by the value of the user-selected unique
+  # column. Only the issue ids are persisted between batch requests
+  # (via ImportInProgress#import_settings); Issue records are loaded lazily
+  # and memoized within a request.
+  class IssueUniqueCache
+    def initialize(ids = {})
+      @ids = ids || {}
+      @issues = {}
+    end
+
+    # Ids by unique value, as persisted between requests.
+    attr_reader :ids
+
+    def key?(value)
+      @ids.key?(value)
+    end
+
+    def [](value)
+      return nil unless (id = @ids[value])
+
+      @issues[value] ||= Issue.find_by_id(id)
+    end
+
+    def []=(value, issue)
+      @ids[value] = issue.id
+      @issues[value] = issue
+    end
+  end
+end

--- a/test/functional/importer_controller_test.rb
+++ b/test/functional/importer_controller_test.rb
@@ -1228,9 +1228,10 @@ class ImporterControllerTest < ActionController::TestCase
     create_iip!('CustomFieldMultiValues', user, project)
   end
 
-  def create_iip!(filename, user, _project)
+  def create_iip!(filename, user, project)
     iip = ImportInProgress.new
     iip.user = user
+    iip.project = project
     iip.csv_data = get_csv(filename)
     # iip.created = DateTime.new(2001,2,3,4,5,6,'+7')
     iip.created = DateTime.now

--- a/test/functional/importer_controller_test.rb
+++ b/test/functional/importer_controller_test.rb
@@ -27,7 +27,7 @@ class ImporterControllerTest < ActionController::TestCase
   test 'should handle multiple values for versions' do
     assert issue_has_none_of_these_multival_versions?(@issue,
                                                       %w[Admin 2013-09-25])
-    post :result, params: build_params(update_issue: 'true')
+    run_import_to_completion(build_params(update_issue: 'true'))
     assert_response :success
     @issue.reload
     assert issue_has_all_these_multival_versions?(@issue, %w[Admin 2013-09-25])
@@ -35,7 +35,7 @@ class ImporterControllerTest < ActionController::TestCase
 
   test 'should handle multiple values' do
     assert issue_has_none_of_these_multifield_vals?(@issue, %w[tag1 tag2])
-    post :result, params: build_params(update_issue: 'true')
+    run_import_to_completion(build_params(update_issue: 'true'))
     assert_response :success
     @issue.reload
     assert issue_has_all_these_multifield_vals?(@issue, %w[tag1 tag2])
@@ -43,7 +43,7 @@ class ImporterControllerTest < ActionController::TestCase
 
   test 'should handle single-value fields' do
     assert_equal 'foobar', @issue.subject
-    post :result, params: build_params(update_issue: 'true')
+    run_import_to_completion(build_params(update_issue: 'true'))
     assert_response :success
     @issue.reload
     assert_equal 'barfooz', @issue.subject
@@ -113,7 +113,7 @@ class ImporterControllerTest < ActionController::TestCase
     Mailer.expects(:deliver_issue_add).never
     Issue.delete_all
     assert_equal 0, Issue.count
-    post :result, params: build_params
+    run_import_to_completion(build_params)
     assert_response :success
     assert_equal 1, Issue.count
     issue = Issue.first
@@ -124,7 +124,7 @@ class ImporterControllerTest < ActionController::TestCase
     assert_equal 'foobar', @issue.subject
     Mailer.expects(:deliver_issue_edit)
 
-    post :result, params: build_params(update_issue: 'true', send_emails: 'true')
+    run_import_to_completion(build_params(update_issue: 'true', send_emails: 'true'))
     assert_response :success
     @issue.reload
     assert_equal 'barfooz', @issue.subject
@@ -135,7 +135,7 @@ class ImporterControllerTest < ActionController::TestCase
     Mailer.expects(:deliver_issue_add)
 
     assert_equal 0, Issue.where(subject: 'barfooz').count
-    post :result, params: build_params(send_emails: 'true')
+    run_import_to_completion(build_params(send_emails: 'true'))
     assert_response :success
     assert_equal 1, Issue.where(subject: 'barfooz').count
   end
@@ -144,7 +144,7 @@ class ImporterControllerTest < ActionController::TestCase
     assert_equal 'foobar', @issue.subject
     Mailer.expects(:deliver_issue_edit).never
 
-    post :result, params: build_params(update_issue: 'true')
+    run_import_to_completion(build_params(update_issue: 'true'))
     assert_response :success
     @issue.reload
     assert_equal 'barfooz', @issue.subject
@@ -152,7 +152,7 @@ class ImporterControllerTest < ActionController::TestCase
 
   test 'should add watchers' do
     assert issue_has_none_of_these_watchers?(@issue, [@user])
-    post :result, params: build_params(update_issue: 'true')
+    run_import_to_completion(build_params(update_issue: 'true'))
     assert_response :success
     @issue.reload
     assert issue_has_all_of_these_watchers?(@issue, [@user])
@@ -163,7 +163,7 @@ class ImporterControllerTest < ActionController::TestCase
     IssueCustomField.where(name: 'Area').each { |icf| icf.update(multiple: false) }
     @iip.destroy
     @iip = create_iip!('KeyValueList', @user, @project)
-    post :result, params: build_params
+    run_import_to_completion(build_params)
     assert_response :success
     assert keyval_vals_for(Issue.find_by!(subject: 'パンケーキ')) == ['Tokyo']
     assert keyval_vals_for(Issue.find_by!(subject: 'たこ焼き')) == ['Osaka']
@@ -174,7 +174,7 @@ class ImporterControllerTest < ActionController::TestCase
     Mailer.expects(:deliver_issue_add).never
     @iip.destroy
     @iip = create_iip!('KeyValueListMultiple', @user, @project)
-    post :result, params: build_params
+    run_import_to_completion(build_params)
     assert_response :success
     assert keyval_vals_for(Issue.find_by!(subject: 'パンケーキ')) == ['Tokyo']
     assert keyval_vals_for(Issue.find_by!(subject: 'たこ焼き')) == ['Osaka']
@@ -186,9 +186,9 @@ class ImporterControllerTest < ActionController::TestCase
   test 'should handle issue relation' do
     other_issue = create_issue!(@project, @user, { subject: 'other_issue' })
     @iip.update!(csv_data: "#,Subject,Duplicated issue ID\n#{@issue.id},set other issue relation,#{other_issue.id}\n")
-    post :result, params: build_params(update_issue: 'true', use_issue_id: '1').tap { |params|
+    run_import_to_completion(build_params(update_issue: 'true', use_issue_id: '1').tap { |params|
                             params[:fields_map]['Duplicated issue ID'] = "issue_relation-#{IssueRelation::TYPE_DUPLICATED}"
-                          }
+                          })
     assert_response :success
     @issue.reload
     assert_equal 'set other issue relation', @issue.subject
@@ -202,7 +202,7 @@ class ImporterControllerTest < ActionController::TestCase
     # CSV: Child issue (#=1, parent=2) comes before Parent issue (#=2)
     # Uses sequential numbers in # column as internal CSV reference (not DB ID)
     @iip.update!(csv_data: "#,Subject,Tracker,Status,Priority,Parent\n1,Child Issue,Defect,New,Critical,2\n2,Parent Issue,Defect,New,Critical,\n")
-    post :result, params: {
+    run_import_to_completion({
       import_timestamp: @iip.created.strftime('%Y-%m-%d %H:%M:%S'),
       unique_field: '#',
       project_id: @project.id,
@@ -214,7 +214,7 @@ class ImporterControllerTest < ActionController::TestCase
         'Priority' => 'standard_field-priority',
         'Parent' => 'standard_field-parent_issue'
       }
-    }
+    })
     assert_response :success
     assert !response.body.include?('Warning'), "Unexpected warning in response"
 
@@ -228,7 +228,7 @@ class ImporterControllerTest < ActionController::TestCase
     # This matches Redmine export format where newer issues appear first
     # #=1 has empty relation value which should be skipped without warning
     @iip.update!(csv_data: "#,Subject,Tracker,Status,Priority,Related issue\n2,Issue Two,Defect,New,Critical,1\n1,Issue One,Defect,New,Critical,\"\"\n")
-    post :result, params: {
+    run_import_to_completion({
       import_timestamp: @iip.created.strftime('%Y-%m-%d %H:%M:%S'),
       unique_field: '#',
       project_id: @project.id,
@@ -240,7 +240,7 @@ class ImporterControllerTest < ActionController::TestCase
         'Priority' => 'standard_field-priority',
         'Related issue' => "issue_relation-#{IssueRelation::TYPE_RELATES}"
       }
-    }
+    })
     assert_response :success
     assert !response.body.include?('Warning'), "Unexpected warning: #{response.body}"
 
@@ -255,7 +255,7 @@ class ImporterControllerTest < ActionController::TestCase
   test 'should warn when deferred reference target is not found in CSV' do
     # CSV: Child issue references parent "999" which doesn't exist in CSV
     @iip.update!(csv_data: "#,Subject,Tracker,Status,Priority,Parent\n1,Orphan Issue,Defect,New,Critical,999\n")
-    post :result, params: {
+    run_import_to_completion({
       import_timestamp: @iip.created.strftime('%Y-%m-%d %H:%M:%S'),
       unique_field: '#',
       project_id: @project.id,
@@ -267,7 +267,7 @@ class ImporterControllerTest < ActionController::TestCase
         'Priority' => 'standard_field-priority',
         'Parent' => 'standard_field-parent_issue'
       }
-    }
+    })
     assert_response :success
     assert response.body.include?('Warning')
     assert response.body.include?('999')
@@ -280,9 +280,9 @@ class ImporterControllerTest < ActionController::TestCase
   test 'should error when assigned_to is missing' do
     @iip.update!(csv_data: "#,Subject,assigned_to\n#{@issue.id},barfooz,JohnDoe\n")
     @issue.reload.update!(assigned_to: @user)
-    post :result, params: build_params(update_issue: 'true').tap { |params|
+    run_import_to_completion(build_params(update_issue: 'true').tap { |params|
                             params[:fields_map]['assigned_to'] = 'standard_field-assigned_to'
-                          }
+                          })
     assert_response :success
     assert response.body.include?('Warning')
     @issue.reload
@@ -293,9 +293,9 @@ class ImporterControllerTest < ActionController::TestCase
   test 'should unset assigned_to when assigned_to user is not assignable' do
     User.create!(login: 'john', firstname: 'John', lastname: 'Doe', mail: 'john.doe@example.com')
     @iip.update!(csv_data: "#,Subject,assigned_to\n#{@issue.id},barfooz,john\n")
-    post :result, params: build_params(update_issue: 'true').tap { |params|
+    run_import_to_completion(build_params(update_issue: 'true').tap { |params|
                             params[:fields_map]['assigned_to'] = 'standard_field-assigned_to'
-                          }
+                          })
     assert_response :success
     assert !response.body.include?('Warning')
     @issue.reload
@@ -310,9 +310,9 @@ class ImporterControllerTest < ActionController::TestCase
     @issue.custom_field_values.detect { |cfv| cfv.custom_field == assigned_by_field }.value = @user
     @iip.update!(csv_data: "#,Subject,assigned_by\n#{@issue.id},barfooz,JeanDoe\n")
     @issue.update!(assigned_to: @user)
-    post :result, params: build_params(update_issue: 'true').tap { |params|
+    run_import_to_completion(build_params(update_issue: 'true').tap { |params|
                             params[:fields_map]['assigned_by'] = 'standard_field-assigned_by'
-                          }
+                          })
     assert_response :success
     assert response.body.include?('Warning')
     @issue.reload
@@ -323,9 +323,9 @@ class ImporterControllerTest < ActionController::TestCase
   test 'should not error when assigned_to is missing but use_anonymous is true' do
     @iip.update!(csv_data: "#,Subject,assigned_to\n#{@issue.id},barfooz,JohnDoe\n")
     @issue.reload.update!(assigned_to: @user)
-    post :result, params: build_params(update_issue: 'true', use_anonymous: 'true').tap { |params|
+    run_import_to_completion(build_params(update_issue: 'true', use_anonymous: 'true').tap { |params|
                             params[:fields_map]['assigned_to'] = 'standard_field-assigned_to'
-                          }
+                          })
     assert_response :success
     assert !response.body.include?('Warning')
     @issue.reload
@@ -338,9 +338,9 @@ class ImporterControllerTest < ActionController::TestCase
     Member.create!(user: user, project: @project, roles: [@role])
 
     @iip.update!(csv_data: "#,Subject,assigned_to\n#{@issue.id},barfooz,#{user.name}\n")
-    post :result, params: build_params(update_issue: 'true').tap { |params|
+    run_import_to_completion(build_params(update_issue: 'true').tap { |params|
                             params[:fields_map]['assigned_to'] = 'standard_field-assigned_to'
-                          }
+                          })
     assert_response :success
     assert_not response.body.include?('Warning')
     @issue.reload
@@ -355,9 +355,9 @@ class ImporterControllerTest < ActionController::TestCase
     @issue.custom_field_values.detect { |cfv| cfv.custom_field == assigned_by_field }.value = @user
     @iip.update!(csv_data: "#,Subject,assigned_by\n#{@issue.id},barfooz,JeanDoe\n")
     @issue.update!(assigned_to: @user)
-    post :result, params: build_params(update_issue: 'true', use_anonymous: 'true').tap { |params|
+    run_import_to_completion(build_params(update_issue: 'true', use_anonymous: 'true').tap { |params|
                             params[:fields_map]['assigned_by'] = 'custom_field-assigned_by'
-                          }
+                          })
     assert_response :success
     assert !response.body.include?('Warning')
     @issue.reload
@@ -373,9 +373,9 @@ class ImporterControllerTest < ActionController::TestCase
     @issue.custom_field_values.detect { |cfv| cfv.custom_field == assigned_by_field }.value = @user
     @iip.update!(csv_data: "#,Subject,assigned_by\n#{@issue.id},barfooz,john\n")
     @issue.update!(assigned_to: @user)
-    post :result, params: build_params(update_issue: 'true', use_anonymous: 'true').tap { |params|
+    run_import_to_completion(build_params(update_issue: 'true', use_anonymous: 'true').tap { |params|
                             params[:fields_map]['assigned_by'] = 'custom_field-assigned_by'
-                          }
+                          })
     assert_response :success
     assert !response.body.include?('Warning')
     @issue.reload
@@ -390,7 +390,7 @@ class ImporterControllerTest < ActionController::TestCase
     ActiveRecord::Base.connection.set_pk_sequence!('issues', 4422)
 
     @iip.update!(csv_data: "#,Subject,Tracker,Priority\n4423,test,Defect,Critical\n")
-    post :result, params: build_params(use_issue_id: '1')
+    run_import_to_completion(build_params(use_issue_id: '1'))
     assert_response :success
     assert !response.body.include?('Warning')
 
@@ -408,7 +408,7 @@ class ImporterControllerTest < ActionController::TestCase
     closed_status = IssueStatus.find_or_create_by!(name: 'Closed', is_closed: true)
     parent = create_issue!(@project, @user, status: closed_status)
     @iip.update!(csv_data: "#,Parent\n#{@issue.id},#{parent.id}\n")
-    post :result, params: build_params(update_issue: 'true', use_issue_id: '1')
+    run_import_to_completion(build_params(update_issue: 'true', use_issue_id: '1'))
     assert_response :success
     assert response.body.include?('Error')
     assert_nil @issue.reload.parent
@@ -421,7 +421,7 @@ class ImporterControllerTest < ActionController::TestCase
     assert !@child.status.is_closed?
     IssueStatus.find_or_create_by!(name: 'Closed', is_closed: true)
     @iip.update!(csv_data: "#,Status\n#{@issue.id},Closed\n")
-    post :result, params: build_params(update_issue: 'true', use_issue_id: '1')
+    run_import_to_completion(build_params(update_issue: 'true', use_issue_id: '1'))
     assert_response :success
     assert response.body.include?('Error')
     assert !@issue.reload.status.is_closed?
@@ -432,7 +432,7 @@ class ImporterControllerTest < ActionController::TestCase
     new_issue = create_issue!(@project, @user, status: closed_status)
     @issue.reload.update!(status: closed_status, parent_id: new_issue.id)
     @iip.update!(csv_data: "#,Status\n#{@issue.id},New\n")
-    post :result, params: build_params(update_issue: 'true', use_issue_id: '1')
+    run_import_to_completion(build_params(update_issue: 'true', use_issue_id: '1'))
     assert_response :success
     assert response.body.include?('Error')
     assert @issue.reload.status.is_closed?
@@ -445,10 +445,10 @@ class ImporterControllerTest < ActionController::TestCase
     @tracker.custom_fields << due_date_field
     Issue.delete_all
     @iip.update!(csv_data: "#,Subject,Tracker,Status,Priority,StartDate,DueDate\n1,Task with dates,Defect,New,Critical,2023-05-15,2023-06-30\n")
-    post :result, params: build_params.tap { |params|
+    run_import_to_completion(build_params.tap { |params|
       params[:fields_map]['StartDate'] = 'custom_field-StartDate'
       params[:fields_map]['DueDate'] = 'custom_field-DueDate'
-    }
+    })
     assert_response :success
     assert !response.body.include?('Warning')
     assert_equal 1, Issue.count
@@ -465,9 +465,9 @@ class ImporterControllerTest < ActionController::TestCase
     @issue.custom_field_values.detect { |cfv| cfv.custom_field == start_date_field }.value = '2023-01-01'
     @issue.save!
     @iip.update!(csv_data: "#,Subject,StartDate\n#{@issue.id},Updated task,2023-12-25\n")
-    post :result, params: build_params(update_issue: 'true').tap { |params|
+    run_import_to_completion(build_params(update_issue: 'true').tap { |params|
       params[:fields_map]['StartDate'] = 'custom_field-StartDate'
-    }
+    })
     assert_response :success
     assert !response.body.include?('Warning')
     @issue.reload
@@ -480,9 +480,9 @@ class ImporterControllerTest < ActionController::TestCase
     @tracker.custom_fields << start_date_field
     Issue.delete_all
     @iip.update!(csv_data: "#,Subject,Tracker,Status,Priority,StartDate\n1,Task with blank date,Defect,New,Critical,\n")
-    post :result, params: build_params.tap { |params|
+    run_import_to_completion(build_params.tap { |params|
       params[:fields_map]['StartDate'] = 'custom_field-StartDate'
-    }
+    })
     assert_response :success
     assert !response.body.include?('Warning')
     assert_equal 1, Issue.count
@@ -497,9 +497,9 @@ class ImporterControllerTest < ActionController::TestCase
     @tracker.custom_fields << invalid_date_field
     Issue.delete_all
     @iip.update!(csv_data: "#,Subject,Tracker,Status,Priority,InvalidDate\n1,Task with invalid date,Defect,New,Critical,not-a-date\n")
-    post :result, params: build_params.tap { |params|
+    run_import_to_completion(build_params.tap { |params|
       params[:fields_map]['InvalidDate'] = 'custom_field-InvalidDate'
-    }
+    })
     assert_response :success
     assert response.body.include?('Warning')
     assert_equal 0, Issue.count
@@ -509,9 +509,9 @@ class ImporterControllerTest < ActionController::TestCase
     Issue.delete_all
     with_settings :date_format => '%Y-%m-%d' do
       @iip.update!(csv_data: "#,Subject,Tracker,Status,Priority,Start date\n1,Task with different date format,Defect,New,Critical,15/05/2023\n")
-      post :result, params: build_params.tap { |params|
+      run_import_to_completion(build_params.tap { |params|
         params[:fields_map]['Start date'] = 'standard_field-start_date'
-      }
+      })
       assert_response :success
       assert !response.body.include?('Warning')
       assert_equal 1, Issue.count
@@ -672,7 +672,7 @@ class ImporterControllerTest < ActionController::TestCase
 
     # With use_issue_id=true, parent should be found by id
     @iip.update!(csv_data: "#,Subject,Tracker,Status,Priority,Parent\n100,Child A,Defect,New,Critical,#{parent.id}\n")
-    post :result, params: build_params(use_issue_id: '1')
+    run_import_to_completion(build_params(use_issue_id: '1'))
     assert_response :success
     assert !response.body.include?('Warning')
 
@@ -688,7 +688,7 @@ class ImporterControllerTest < ActionController::TestCase
     # Before fix: Would incorrectly use id-based search
     # After fix: Uses query filter which should fail or behave differently
     @iip.update!(csv_data: "#,Subject,Tracker,Status,Priority,Parent\n101,Child B,Defect,New,Critical,#{parent.id}\n")
-    post :result, params: build_params # use_issue_id defaults to false
+    run_import_to_completion(build_params) # use_issue_id defaults to false
     assert_response :success
 
     # After the fix, since 'standard_field-id' is not a valid IssueQuery filter,
@@ -709,7 +709,166 @@ class ImporterControllerTest < ActionController::TestCase
     end
   end
 
+  # --- Batched import (acceptance tests) ---
+  # The import must follow Redmine core's design: POST :result only stores the
+  # import settings and redirects to the run page; each POST :run processes at
+  # most max_items_per_request rows (or 10 seconds) and redirects back to run
+  # until every row is consumed, then redirects to the result page.
+
+  test 'should import in batches across multiple run requests and resume' do
+    ImporterController.any_instance.stubs(:max_items_per_request).returns(2)
+    @iip.update!(csv_data: "#,Subject,Tracker,Status,Priority\n" \
+                           "1,Batch One,Defect,New,Critical\n" \
+                           "2,Batch Two,Defect,New,Critical\n" \
+                           "3,Batch Three,Defect,New,Critical\n")
+
+    assert_no_difference 'Issue.count' do
+      post :result, params: batch_run_params
+      assert_redirected_to "/projects/#{@project.identifier}/importer/run"
+    end
+
+    assert_difference 'Issue.count', 2 do
+      post :run, params: { project_id: @project.identifier }
+      assert_redirected_to "/projects/#{@project.identifier}/importer/run"
+    end
+
+    assert_difference 'Issue.count', 1 do
+      post :run, params: { project_id: @project.identifier }
+      assert_redirected_to "/projects/#{@project.identifier}/importer/result"
+    end
+
+    assert @iip.reload.finished, 'import should be marked as finished'
+
+    get :result, params: { project_id: @project.identifier }
+    assert_response :success
+    %w[Batch\ One Batch\ Two Batch\ Three].each do |subject|
+      assert Issue.exists?(subject: subject), "expected issue '#{subject}' to be created"
+    end
+  end
+
+  test 'should resolve parent defined in a later batch' do
+    ImporterController.any_instance.stubs(:max_items_per_request).returns(1)
+    @iip.update!(csv_data: "#,Subject,Tracker,Status,Priority,Parent\n" \
+                           "1,Batch Child,Defect,New,Critical,2\n" \
+                           "2,Batch Parent,Defect,New,Critical,\n")
+
+    run_import_to_completion(batch_run_params(with_parent: true))
+    assert_response :success
+    assert_not response.body.include?('Warning'), "unexpected warning: #{response.body}"
+
+    child = Issue.find_by!(subject: 'Batch Child')
+    parent = Issue.find_by!(subject: 'Batch Parent')
+    assert_equal parent.id, child.parent_id
+  end
+
+  test 'should record failed rows without retrying them and keep counters across batches' do
+    ImporterController.any_instance.stubs(:max_items_per_request).returns(1)
+    @iip.update!(csv_data: "#,Subject,Tracker,Status,Priority,Start date\n" \
+                           "1,Batch Good One,Defect,New,Critical,2026-08-01\n" \
+                           "2,Batch Broken,Defect,New,Critical,not-a-date\n" \
+                           "3,Batch Good Two,Defect,New,Critical,2026-08-02\n")
+    params = batch_run_params(extra_fields: { 'Start date' => 'standard_field-start_date' })
+
+    post :result, params: params
+    assert_redirected_to "/projects/#{@project.identifier}/importer/run"
+
+    assert_difference 'Issue.count', 1 do
+      post :run, params: { project_id: @project.identifier }
+      assert_redirected_to "/projects/#{@project.identifier}/importer/run"
+    end
+
+    # The broken row must be recorded as failed and never retried
+    assert_no_difference 'Issue.count' do
+      post :run, params: { project_id: @project.identifier }
+      assert_redirected_to "/projects/#{@project.identifier}/importer/run"
+    end
+
+    assert_difference 'Issue.count', 1 do
+      post :run, params: { project_id: @project.identifier }
+      assert_redirected_to "/projects/#{@project.identifier}/importer/result"
+    end
+
+    get :result, params: { project_id: @project.identifier }
+    assert_response :success
+    assert response.body.include?('not-a-date'),
+           'failed row should be listed on the result page'
+    assert response.body.include?('Batch Broken'),
+           'failed row values should be listed on the result page'
+    assert_nil Issue.find_by(subject: 'Batch Broken')
+  end
+
+  test 'run page should show import progress' do
+    ImporterController.any_instance.stubs(:max_items_per_request).returns(1)
+    @iip.update!(csv_data: "#,Subject,Tracker,Status,Priority\n" \
+                           "1,Batch One,Defect,New,Critical\n" \
+                           "2,Batch Two,Defect,New,Critical\n")
+
+    post :result, params: batch_run_params
+    get :run, params: { project_id: @project.identifier }
+    assert_response :success
+    assert_select '#import-progress'
+  end
+
+  test 'should reject re-submitting the mapping form for a started import' do
+    @iip.update!(csv_data: "#,Subject,Tracker,Status,Priority\n" \
+                           "1,Batch One,Defect,New,Critical\n")
+    params = batch_run_params
+
+    run_import_to_completion(params)
+    assert_equal 1, Issue.where(subject: 'Batch One').count
+
+    # Re-submitting the same mapping form must not restart the import
+    assert_no_difference 'Issue.count' do
+      post :result, params: params
+      assert_response :success
+      assert flash[:error].present?
+    end
+  end
+
+  test 'run without import in progress should redirect to importer index' do
+    ImportInProgress.delete_all
+    post :run, params: { project_id: @project.identifier }
+    assert_redirected_to project_importer_path(project_id: @project.identifier)
+  end
+
   protected
+
+  # Drives the batched import flow to completion: POST :result stores the
+  # settings, then POST :run is repeated until it redirects to the result
+  # page, which is finally fetched so callers can assert on the report.
+  # Falls through when POST :result did not start an import (validation
+  # errors keep the legacy render-with-flash behavior).
+  def run_import_to_completion(params)
+    post :result, params: params
+    return unless response.redirect_url&.include?('/importer/run')
+
+    40.times do
+      post :run, params: { project_id: params[:project_id] }
+      unless response.redirect_url&.include?('/importer/run')
+        get :result, params: { project_id: params[:project_id] }
+        return
+      end
+    end
+    flunk 'import did not finish within 40 run requests'
+  end
+
+  def batch_run_params(with_parent: false, extra_fields: {})
+    fields_map = {
+      '#' => 'standard_field-id',
+      'Subject' => 'standard_field-subject',
+      'Tracker' => 'standard_field-tracker',
+      'Status' => 'standard_field-status',
+      'Priority' => 'standard_field-priority'
+    }
+    fields_map['Parent'] = 'standard_field-parent_issue' if with_parent
+    fields_map.merge!(extra_fields)
+    {
+      import_timestamp: @iip.reload.created.strftime('%Y-%m-%d %H:%M:%S'),
+      unique_field: '#',
+      project_id: @project.identifier,
+      fields_map: fields_map
+    }
+  end
 
   def build_params(opts = {})
     @iip.reload

--- a/test/functional/importer_controller_test.rb
+++ b/test/functional/importer_controller_test.rb
@@ -845,6 +845,103 @@ class ImporterControllerTest < ActionController::TestCase
     assert_select '#import-progress'
   end
 
+  test 'should roll back the whole batch when a request fails mid-batch and not duplicate rows on retry' do
+    @iip.update!(csv_data: "#,Subject,Tracker,Status,Priority\n" \
+                           "1,Batch One,Defect,New,Critical\n" \
+                           "2,Batch Two,Defect,New,Critical\n" \
+                           "3,Batch Three,Defect,New,Critical\n")
+    post :result, params: batch_run_params
+    assert_redirected_to "/projects/#{@project.identifier}/importer/run"
+
+    # Fail on the third row of the first batch with an error the row loop
+    # does not rescue
+    ImporterController.any_instance.stubs(:update_project_issues_stat)
+                      .returns(nil).then.returns(nil).then.raises(RuntimeError, 'boom')
+    assert_no_difference 'Issue.count' do
+      assert_raises(RuntimeError) do
+        post :run, params: { project_id: @project.identifier }
+      end
+    end
+    ImporterController.any_instance.unstub(:update_project_issues_stat)
+
+    # The retry must import every row exactly once
+    assert_difference 'Issue.count', 3 do
+      post :run, params: { project_id: @project.identifier }
+      assert_redirected_to "/projects/#{@project.identifier}/importer/result"
+    end
+    %w[One Two Three].each do |n|
+      assert_equal 1, Issue.where(subject: "Batch #{n}").count
+    end
+  end
+
+  test 'should fail the row instead of crashing when a cached issue was deleted between batches' do
+    ImporterController.any_instance.stubs(:max_items_per_request).returns(1)
+    key_field = IssueCustomField.create!(name: 'Key', field_format: 'string',
+                                         is_filter: true, is_for_all: true)
+    @tracker.custom_fields << key_field
+    @tracker.save!
+    @iip.update!(csv_data: "Key,Subject,Tracker,Status,Priority,Parent\n" \
+                           "P1,Batch Parent,Defect,New,Critical,\n" \
+                           "C1,Batch Child,Defect,New,Critical,P1\n")
+    post :result, params: {
+      import_timestamp: @iip.reload.created.strftime('%Y-%m-%d %H:%M:%S'),
+      unique_field: 'Key',
+      project_id: @project.identifier,
+      fields_map: {
+        'Key' => 'custom_field-Key',
+        'Subject' => 'standard_field-subject',
+        'Tracker' => 'standard_field-tracker',
+        'Status' => 'standard_field-status',
+        'Priority' => 'standard_field-priority',
+        'Parent' => 'standard_field-parent_issue'
+      }
+    }
+    assert_redirected_to "/projects/#{@project.identifier}/importer/run"
+
+    post :run, params: { project_id: @project.identifier }
+    Issue.find_by!(subject: 'Batch Parent').destroy
+
+    post :run, params: { project_id: @project.identifier }
+    assert_redirected_to "/projects/#{@project.identifier}/importer/result"
+
+    get :result, params: { project_id: @project.identifier }
+    assert_response :success
+    child = Issue.find_by!(subject: 'Batch Child')
+    assert_nil child.parent_id
+  end
+
+  test 'should clean up stale imports only when the import finishes' do
+    ImporterController.any_instance.stubs(:max_items_per_request).returns(1)
+    stale = ImportInProgress.create!(user: User.find_by!(login: 'alice'),
+                                     created: Time.new - 4 * 24 * 60 * 60,
+                                     csv_data: "Subject\nstale\n",
+                                     encoding: 'U', col_sep: ',', quote_char: '"')
+    @iip.update!(csv_data: "#,Subject,Tracker,Status,Priority\n" \
+                           "1,Batch One,Defect,New,Critical\n" \
+                           "2,Batch Two,Defect,New,Critical\n")
+
+    post :result, params: batch_run_params
+    post :run, params: { project_id: @project.identifier }
+    assert ImportInProgress.exists?(stale.id),
+           'an unfinished batch must not garbage-collect other imports'
+
+    post :run, params: { project_id: @project.identifier }
+    assert_redirected_to "/projects/#{@project.identifier}/importer/result"
+    assert_not ImportInProgress.exists?(stale.id),
+               'finishing the import must garbage-collect stale imports'
+  end
+
+  test 'should record a row failure when the issue id is already taken' do
+    @iip.update!(csv_data: "#,Subject,Tracker,Status,Priority\n" \
+                           "#{@issue.id},Duplicate Id,Defect,New,Critical\n" \
+                           "70999,Batch Fresh,Defect,New,Critical\n")
+    run_import_to_completion(batch_run_params(extra: { use_issue_id: '1' }))
+    assert_response :success
+    assert_equal 'foobar', @issue.reload.subject, 'the existing issue must not be touched'
+    assert Issue.exists?(id: 70_999), 'rows after the conflicting one must still be imported'
+    assert response.body.include?(I18n.t(:error_issue_id_taken))
+  end
+
   test 'should reject re-submitting the mapping form for a started import' do
     @iip.update!(csv_data: "#,Subject,Tracker,Status,Priority\n" \
                            "1,Batch One,Defect,New,Critical\n")
@@ -888,7 +985,7 @@ class ImporterControllerTest < ActionController::TestCase
     flunk 'import did not finish within 40 run requests'
   end
 
-  def batch_run_params(with_parent: false, extra_fields: {})
+  def batch_run_params(with_parent: false, extra_fields: {}, extra: {})
     fields_map = {
       '#' => 'standard_field-id',
       'Subject' => 'standard_field-subject',
@@ -903,7 +1000,7 @@ class ImporterControllerTest < ActionController::TestCase
       unique_field: '#',
       project_id: @project.identifier,
       fields_map: fields_map
-    }
+    }.merge(extra)
   end
 
   def build_params(opts = {})

--- a/test/functional/importer_controller_test.rb
+++ b/test/functional/importer_controller_test.rb
@@ -761,6 +761,42 @@ class ImporterControllerTest < ActionController::TestCase
     assert_equal parent.id, child.parent_id
   end
 
+  test 'should split update mode import across multiple run requests' do
+    ImporterController.any_instance.stubs(:max_items_per_request).returns(2)
+    second = create_issue!(@project, @user, { id: 70_386, subject: 'second' })
+    third = create_issue!(@project, @user, { id: 70_387, subject: 'third' })
+    @iip.update!(csv_data: "#,Subject\n" \
+                           "#{@issue.id},Updated One\n" \
+                           "#{second.id},Updated Two\n" \
+                           "#{third.id},Updated Three\n")
+    params = {
+      import_timestamp: @iip.reload.created.strftime('%Y-%m-%d %H:%M:%S'),
+      unique_field: '#',
+      project_id: @project.identifier,
+      update_issue: 'true',
+      use_issue_id: '1',
+      fields_map: {
+        '#' => 'standard_field-id',
+        'Subject' => 'standard_field-subject'
+      }
+    }
+
+    assert_no_difference 'Issue.count' do
+      post :result, params: params
+      assert_redirected_to "/projects/#{@project.identifier}/importer/run"
+
+      post :run, params: { project_id: @project.identifier }
+      assert_redirected_to "/projects/#{@project.identifier}/importer/run"
+      assert_equal 'Updated Two', second.reload.subject
+      assert_equal 'third', third.reload.subject, 'third row must not be processed in the first batch'
+
+      post :run, params: { project_id: @project.identifier }
+      assert_redirected_to "/projects/#{@project.identifier}/importer/result"
+      assert_equal 'Updated Three', third.reload.subject
+    end
+    assert_equal 'Updated One', @issue.reload.subject
+  end
+
   test 'should record failed rows without retrying them and keep counters across batches' do
     ImporterController.any_instance.stubs(:max_items_per_request).returns(1)
     @iip.update!(csv_data: "#,Subject,Tracker,Status,Priority,Start date\n" \

--- a/test/functional/importer_controller_test.rb
+++ b/test/functional/importer_controller_test.rb
@@ -1001,6 +1001,8 @@ class ImporterControllerTest < ActionController::TestCase
     assert_redirected_to "/projects/#{@project.identifier}/importer/result"
     assert_nil flash[:error],
                'a resubmitted form of a finished import must not show an error'
+    assert_equal I18n.t(:notice_import_already_finished), flash[:notice],
+                 'the user must be told the shown report is not a fresh import'
   end
 
   test 'should reject a mapping form that was superseded by a newer upload' do

--- a/test/functional/importer_controller_test.rb
+++ b/test/functional/importer_controller_test.rb
@@ -1060,6 +1060,93 @@ class ImporterControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
+  # --- Per-project isolation of match (refs #117121) ---
+  # Starting an import must only replace the user's previous import on the
+  # same project: an import the user has in progress on another project is
+  # independent and must not be discarded.
+
+  test 'should keep an import running on another project when a new one is matched' do
+    @iip.update!(csv_data: cross_project_csv)
+    post :result, params: batch_run_params
+    assert_redirected_to "/projects/#{@project.identifier}/importer/run"
+    settings_before = @iip.reload.settings
+    assert settings_before.present?
+
+    @other_project = create_other_project!
+    post_match!(@other_project,
+                "#,Subject,Tracker,Status,Priority\n" \
+                "70011,Other One,Defect,New,Critical\n")
+    assert_response :success
+
+    assert ImportInProgress.exists?(@iip.id),
+           'match on another project must not delete the running import'
+    @iip.reload
+    assert_equal settings_before, @iip.settings,
+                 'the running import must keep its stored mapping'
+    assert_equal 2, ImportInProgress.where(user_id: @user.id).count,
+                 'each project keeps its own import in progress'
+
+    # The interrupted project can still finish its import afterwards
+    post :run, params: { project_id: @project.identifier }
+    assert_redirected_to "/projects/#{@project.identifier}/importer/result"
+    assert_equal 3, @project.issues.where('subject LIKE ?', 'Cross%').count
+  end
+
+  test 'should replace the previous import when matched again on the same project' do
+    @iip.update!(csv_data: cross_project_csv)
+    post :result, params: batch_run_params
+    assert @iip.reload.settings.present?
+
+    post_match!(@project,
+                "#,Subject,Tracker,Status,Priority\n" \
+                "70012,Fresh One,Defect,New,Critical\n")
+    assert_response :success
+
+    rows = ImportInProgress.where(user_id: @user.id, project_id: @project.id)
+    assert_equal 1, rows.count, 'the same project keeps a single import in progress'
+    assert_includes rows.first.csv_data, 'Fresh One'
+    assert rows.first.settings.blank?, 'a re-matched import starts from scratch'
+  end
+
+  test 'should run imports on two projects independently to completion' do
+    a_csv = +"#,Subject,Tracker,Status,Priority\n"
+    b_csv = +"#,Subject,Tracker,Status,Priority\n"
+    8.times do |i|
+      a_csv << "#{70_101 + i},A-#{i + 1},Defect,New,Critical\n"
+      b_csv << "#{70_201 + i},B-#{i + 1},Defect,New,Critical\n"
+    end
+    @iip.update!(csv_data: a_csv)
+    post :result, params: batch_run_params
+
+    @other_project = create_other_project!
+    other_iip = ImportInProgress.create!(user: @user, project: @other_project,
+                                         csv_data: b_csv, created: DateTime.now,
+                                         encoding: 'UTF-8', col_sep: ',', quote_char: '"')
+    post :result, params: batch_run_params.merge(
+      project_id: @other_project.identifier,
+      import_timestamp: other_iip.created.strftime('%Y-%m-%d %H:%M:%S')
+    )
+
+    # Alternate the polling between the two projects until both finish
+    # (each batch imports at most 5 rows, so each import needs two runs)
+    10.times do
+      break if @iip.reload.finished && other_iip.reload.finished
+
+      [@project, @other_project].each do |project|
+        post :run, params: { project_id: project.identifier }
+      end
+    end
+
+    assert @iip.reload.finished, 'the first import must run to completion'
+    assert other_iip.reload.finished, 'the second import must run to completion'
+    assert_equal 8, @project.issues.where('subject LIKE ?', 'A-%').count
+    assert_equal 8, @other_project.issues.where('subject LIKE ?', 'B-%').count
+    assert_equal 0, @project.issues.where('subject LIKE ?', 'B-%').count,
+                 'no row may leak into the other project'
+    assert_equal 0, @other_project.issues.where('subject LIKE ?', 'A-%').count,
+                 'no row may leak into the other project'
+  end
+
   protected
 
   # A second project the import was NOT started on, fully able to receive
@@ -1078,6 +1165,23 @@ class ImporterControllerTest < ActionController::TestCase
       "1,Cross One,Defect,New,Critical\n" \
       "2,Cross Two,Defect,New,Critical\n" \
       "3,Cross Three,Defect,New,Critical\n"
+  end
+
+  # Uploads csv_data to the project's match action, as the import form does.
+  def post_match!(project, csv_data)
+    file = Tempfile.new(['test', '.csv'])
+    file.write(csv_data)
+    file.rewind
+    post :match, params: {
+      project_id: project.identifier,
+      file: Rack::Test::UploadedFile.new(file.path, 'text/csv'),
+      wrapper: '"',
+      splitter: ',',
+      encoding: 'UTF-8'
+    }
+  ensure
+    file.close
+    file.unlink
   end
 
   # Drives the batched import flow to completion: POST :result stores the

--- a/test/functional/importer_controller_test.rb
+++ b/test/functional/importer_controller_test.rb
@@ -15,6 +15,7 @@ class ImporterControllerTest < ActionController::TestCase
     @tracker.save!
     @project.trackers << @tracker
     @project.save!
+    @project.enable_module!(:importer)
     @role = Role.create! name: 'ADMIN', permissions: %i[import view_issues]
     @user = create_user!(@role, @project)
     @iip = create_iip_for_multivalues!(@user, @project)
@@ -964,7 +965,120 @@ class ImporterControllerTest < ActionController::TestCase
     assert_redirected_to project_importer_path(project_id: @project.identifier)
   end
 
+  # --- Cross-project protection (refs #117121) ---
+  # An import started on one project must not be visible or resumable through
+  # another project's URL: the batch target project is derived from the URL,
+  # so a foreign URL would import the remaining rows into the wrong project.
+  # run/result must also be covered by the :import permission (project module
+  # enabled and role permission).
+
+  test 'should not show run progress via another project URL' do
+    @other_project = create_other_project!
+    @iip.update!(csv_data: cross_project_csv)
+    post :result, params: batch_run_params
+    assert_redirected_to "/projects/#{@project.identifier}/importer/run"
+
+    get :run, params: { project_id: @other_project.identifier }
+    assert_redirected_to project_importer_path(project_id: @other_project.identifier)
+    assert flash[:error].present?,
+           'a foreign project URL must not show the progress page'
+  end
+
+  test 'should not process batches via another project URL' do
+    @other_project = create_other_project!
+    @iip.update!(csv_data: cross_project_csv)
+    post :result, params: batch_run_params
+
+    assert_no_difference 'Issue.count' do
+      post :run, params: { project_id: @other_project.identifier }
+    end
+    assert_redirected_to project_importer_path(project_id: @other_project.identifier)
+    assert_equal 0, @other_project.issues.count,
+                 'no row may be imported into the project from the URL'
+    assert_not @iip.reload.finished,
+               'the import must not advance through a foreign project URL'
+  end
+
+  test 'should not show the result of an import finished on another project' do
+    @other_project = create_other_project!
+    @iip.update!(csv_data: cross_project_csv)
+    run_import_to_completion(batch_run_params)
+    assert_response :success
+
+    get :result, params: { project_id: @other_project.identifier }
+    assert_response :success
+    assert flash[:error].present?,
+           'a foreign project URL must not show the import result'
+  end
+
+  test 'should not start an import whose mapping was submitted to another project' do
+    @other_project = create_other_project!
+    assert_no_difference 'Issue.count' do
+      post :result, params: batch_run_params.merge(project_id: @other_project.identifier)
+    end
+    assert_response :success
+    assert flash[:error].present?
+    assert @iip.reload.settings.blank?,
+           'the mapping must not be stored for a foreign project'
+  end
+
+  test 'should refuse the run page when the importer module is disabled on the project' do
+    @project.disable_module!(:importer)
+    get :run, params: { project_id: @project.identifier }
+    assert_response :forbidden
+  end
+
+  test 'should refuse to process a batch when the importer module is disabled on the project' do
+    @iip.update!(csv_data: cross_project_csv)
+    post :result, params: batch_run_params
+    @project.disable_module!(:importer)
+
+    assert_no_difference 'Issue.count' do
+      post :run, params: { project_id: @project.identifier }
+    end
+    assert_response :forbidden
+  end
+
+  test 'should refuse the result page when the importer module is disabled on the project' do
+    @project.disable_module!(:importer)
+    get :result, params: { project_id: @project.identifier }
+    assert_response :forbidden
+  end
+
+  test 'should refuse the run page for a user without the import permission' do
+    role = Role.create! name: 'NO_IMPORT', permissions: %i[view_issues]
+    user = User.new(firstname: 'No', lastname: 'Import', mail: 'no.import@example.com')
+    user.login = 'noimport'
+    membership = user.memberships.build(project: @project)
+    membership.roles << role
+    membership.principal = user
+    user.pref.auto_watch_on = nil if Redmine::VERSION.to_s.to_f >= 5.1
+    user.save!
+    User.stubs(:current).returns(user)
+
+    get :run, params: { project_id: @project.identifier }
+    assert_response :forbidden
+  end
+
   protected
+
+  # A second project the import was NOT started on, fully able to receive
+  # imported issues (importer module enabled, same tracker), so the
+  # cross-project tests fail loudly if rows leak into it.
+  def create_other_project!
+    project = Project.create! name: 'other', identifier: 'importer_other_project'
+    project.trackers << @tracker unless project.trackers.include?(@tracker)
+    project.save!
+    project.enable_module!(:importer)
+    project
+  end
+
+  def cross_project_csv
+    "#,Subject,Tracker,Status,Priority\n" \
+      "1,Cross One,Defect,New,Critical\n" \
+      "2,Cross Two,Defect,New,Critical\n" \
+      "3,Cross Three,Defect,New,Critical\n"
+  end
 
   # Drives the batched import flow to completion: POST :result stores the
   # settings, then POST :run is repeated until it redirects to the result

--- a/test/functional/importer_controller_test.rb
+++ b/test/functional/importer_controller_test.rb
@@ -943,7 +943,49 @@ class ImporterControllerTest < ActionController::TestCase
     assert response.body.include?(I18n.t(:error_issue_id_taken))
   end
 
-  test 'should reject re-submitting the mapping form for a started import' do
+  # --- Mapping form resubmission (refs #117120) ---
+  # Pressing the browser's back button from the progress page and submitting
+  # the mapping form again must never restart the import (that would
+  # duplicate the already imported rows), but it must not cut the running
+  # import off with a misleading "superseded" error either: the user is sent
+  # back to the import they already started.
+
+  test 'should redirect a resubmitted mapping form to the progress page while the import is running' do
+    ImporterController.any_instance.stubs(:max_items_per_request).returns(1)
+    @iip.update!(csv_data: "#,Subject,Tracker,Status,Priority\n" \
+                           "1,Resubmit One,Defect,New,Critical\n" \
+                           "2,Resubmit Two,Defect,New,Critical\n" \
+                           "3,Resubmit Three,Defect,New,Critical\n")
+    params = batch_run_params
+
+    post :result, params: params
+    assert_redirected_to "/projects/#{@project.identifier}/importer/run"
+    post :run, params: { project_id: @project.identifier }
+    assert_equal 1, @iip.reload.position
+
+    # Browser back + "Import" again resubmits the very same mapping form
+    assert_no_difference 'Issue.count' do
+      post :result, params: params
+    end
+    assert_redirected_to "/projects/#{@project.identifier}/importer/run"
+    assert_nil flash[:error], 'a resubmitted form of a running import must not show an error'
+    assert_equal I18n.t(:notice_import_already_running), flash[:notice]
+    @iip.reload
+    assert_not @iip.finished, 'the running import must not be cut off'
+    assert_equal 1, @iip.position, 'the import progress must be preserved'
+
+    # The progress page's polling picks the import up where it left off
+    post :run, params: { project_id: @project.identifier }
+    assert_redirected_to "/projects/#{@project.identifier}/importer/run"
+    post :run, params: { project_id: @project.identifier }
+    assert_redirected_to "/projects/#{@project.identifier}/importer/result"
+    %w[One Two Three].each do |n|
+      assert_equal 1, Issue.where(subject: "Resubmit #{n}").count,
+                   "row 'Resubmit #{n}' must be imported exactly once"
+    end
+  end
+
+  test 'should redirect a resubmitted mapping form to the result page after the import finished' do
     @iip.update!(csv_data: "#,Subject,Tracker,Status,Priority\n" \
                            "1,Batch One,Defect,New,Critical\n")
     params = batch_run_params
@@ -951,12 +993,29 @@ class ImporterControllerTest < ActionController::TestCase
     run_import_to_completion(params)
     assert_equal 1, Issue.where(subject: 'Batch One').count
 
-    # Re-submitting the same mapping form must not restart the import
+    # Re-submitting the same mapping form must not restart the import; the
+    # user is shown the report of the import that already ran instead.
     assert_no_difference 'Issue.count' do
       post :result, params: params
-      assert_response :success
-      assert flash[:error].present?
     end
+    assert_redirected_to "/projects/#{@project.identifier}/importer/result"
+    assert_nil flash[:error],
+               'a resubmitted form of a finished import must not show an error'
+  end
+
+  test 'should reject a mapping form that was superseded by a newer upload' do
+    params = batch_run_params # captures the current form timestamp
+
+    # Uploading a new file replaces the ImportInProgress record (see :match),
+    # so the old form's timestamp no longer matches: that form really was
+    # superseded by another import and must keep being rejected.
+    @iip.update!(created: @iip.created + 1.hour)
+
+    assert_no_difference 'Issue.count' do
+      post :result, params: params
+    end
+    assert_response :success
+    assert_equal I18n.t(:error_import_superseded), flash[:error]
   end
 
   test 'run without import in progress should redirect to importer index' do

--- a/test/performance/generate_import_csv.rb
+++ b/test/performance/generate_import_csv.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+# Generates large CSV files for benchmarking ImporterController#result.
+#
+# Usage (CLI):
+#   ruby test/performance/generate_import_csv.rb ROWS [VARIANT] [OUTPUT]
+#
+#   ROWS    - number of data rows to generate
+#   VARIANT - basic | custom_fields | parent | full (default: basic)
+#   OUTPUT  - output file path (default: stdout)
+#
+# Usage (from tests):
+#   require_relative 'generate_import_csv'
+#   csv = ImportCsvGenerator.generate(rows: 5000, variant: :full)
+#
+# Variants (all include a sequential "#" column used as the unique field):
+#   basic         - standard fields only (subject, description, priority,
+#                   tracker, status). Exercises the per-row master-data
+#                   lookups in the import loop.
+#   custom_fields - basic + a multi-value list custom field column ("Tags").
+#   parent        - basic + a "Parent" column. Within each group of
+#                   GROUP_SIZE rows the parent row comes LAST, so the child
+#                   rows are forward references that go through the deferred
+#                   callback mechanism (matches Redmine's export order where
+#                   newer issues appear first).
+#   full          - all of the above.
+require 'csv'
+
+module ImportCsvGenerator
+  GROUP_SIZE = 10
+
+  DEFAULTS = {
+    priority: 'Critical',
+    tracker: 'Defect',
+    status: 'New',
+    tags: 'tag1,tag2'
+  }.freeze
+
+  module_function
+
+  def generate(rows:, variant: :basic, **overrides)
+    variant = variant.to_sym
+    values = DEFAULTS.merge(overrides)
+    with_tags = %i[custom_fields full].include?(variant)
+    with_parent = %i[parent full].include?(variant)
+
+    CSV.generate(force_quotes: true) do |csv|
+      csv << headers(with_tags: with_tags, with_parent: with_parent)
+      1.upto(rows) do |n|
+        row = []
+        row << n.to_s
+        row << "Benchmark issue #{n}"
+        row << "Generated row #{n} for import benchmark."
+        row << values[:priority]
+        row << values[:tracker]
+        row << values[:status]
+        row << values[:tags] if with_tags
+        row << parent_ref(n, rows) if with_parent
+        csv << row
+      end
+    end
+  end
+
+  def headers(with_tags:, with_parent:)
+    headers = ['#']
+    headers += %w[Subject Description Priority Tracker Status]
+    headers << 'Tags' if with_tags
+    headers << 'Parent' if with_parent
+    headers
+  end
+
+  # The last row of each group is the parent; earlier rows in the group
+  # reference it before it exists (forward reference).
+  def parent_ref(n, rows)
+    group_last = [((n - 1) / GROUP_SIZE + 1) * GROUP_SIZE, rows].min
+    n == group_last ? '' : group_last.to_s
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  rows = Integer(ARGV.fetch(0))
+  variant = (ARGV[1] || 'basic').to_sym
+  csv = ImportCsvGenerator.generate(rows: rows, variant: variant)
+  if ARGV[2]
+    File.write(ARGV[2], csv)
+    warn "wrote #{rows} rows (#{variant}) to #{ARGV[2]}"
+  else
+    print csv
+  end
+end

--- a/test/performance/import_benchmark_test.rb
+++ b/test/performance/import_benchmark_test.rb
@@ -41,6 +41,7 @@ class ImportBenchmarkTest < ActionController::TestCase
     @tracker.save!
     @project.trackers << @tracker
     @project.save!
+    @project.enable_module!(:importer)
     IssuePriority.find_or_create_by!(name: 'Critical')
     @role = Role.create! name: 'BENCH', permissions: %i[import view_issues]
     @user = create_user!(@role, @project)
@@ -123,6 +124,7 @@ class ImportBenchmarkTest < ActionController::TestCase
     ImportInProgress.where(user_id: @user.id).delete_all
     iip = ImportInProgress.new
     iip.user = @user
+    iip.project = @project
     iip.csv_data = csv_data
     iip.created = DateTime.now
     iip.encoding = 'UTF-8'

--- a/test/performance/import_benchmark_test.rb
+++ b/test/performance/import_benchmark_test.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+# Benchmark for the batched import flow (POST result -> repeated POST run)
+# with large CSV files. The number to watch is max_req_s: with the batch
+# design no single request may exceed the 10-second budget.
+#
+# This file lives outside test/{unit,functional,integration,system} on
+# purpose: `rake redmine:plugins:test` and CI must not pick it up. Run it
+# explicitly from the Redmine root:
+#
+#   bundle exec ruby -Itest plugins/redmine_importer/test/performance/import_benchmark_test.rb
+#
+# Row counts and variants can be overridden via environment variables:
+#
+#   BENCH_ROWS=100,500 BENCH_VARIANTS=basic,full bundle exec ruby -Itest ...
+#
+# No thresholds are asserted (numbers vary by machine); the output is the
+# deliverable.
+#
+# Reference numbers (arm64 mac, PostgreSQL, 2026-08): full/5000 finishes in
+# ~5 minutes total with max_req_s < 1s; the pre-batching implementation
+# needed 85s for a single basic/5000 request and never finished full/5000.
+require File.expand_path('../test_helper', __dir__)
+require_relative 'generate_import_csv'
+
+$stdout.sync = true
+
+class ImportBenchmarkTest < ActionController::TestCase
+  tests ImporterController
+
+  fixtures :users
+
+  ROW_COUNTS = ENV.fetch('BENCH_ROWS', '500,1000,5000').split(',').map { |s| Integer(s.strip) }
+  VARIANTS = ENV.fetch('BENCH_VARIANTS', 'basic,full').split(',').map { |s| s.strip.to_sym }
+
+  def setup
+    ActionController::Base.allow_forgery_protection = false
+    @project = Project.create! name: 'bench', identifier: 'import-benchmark-test'
+    @tracker = Tracker.new(name: 'Defect')
+    @tracker.default_status = IssueStatus.find_or_create_by!(name: 'New')
+    @tracker.save!
+    @project.trackers << @tracker
+    @project.save!
+    IssuePriority.find_or_create_by!(name: 'Critical')
+    @role = Role.create! name: 'BENCH', permissions: %i[import view_issues]
+    @user = create_user!(@role, @project)
+    create_tags_field!(@project, @tracker)
+    User.stubs(:current).returns(@user)
+  end
+
+  test 'benchmark batched import flow' do
+    puts
+    puts "Batched import benchmark (plugin v#{Redmine::Plugin.find(:redmine_importer).version})"
+    puts format('%-14s %8s %9s %9s %10s %10s %12s %8s',
+                'variant', 'rows', 'requests', 'total_s', 'max_req_s', 'avg_req_s', 'queries', 'created')
+
+    VARIANTS.each do |variant|
+      ROW_COUNTS.each do |rows|
+        iip = create_iip!(ImportCsvGenerator.generate(rows: rows, variant: variant))
+        issues_before = Issue.count
+        GC.start
+
+        post :result, params: bench_params(iip, variant)
+        assert_response :redirect
+
+        request_times = []
+        total_queries = 0
+        loop do
+          elapsed, queries = measure do
+            post :run, params: { project_id: @project.identifier }
+          end
+          request_times << elapsed
+          total_queries += queries
+          break unless response.redirect_url&.include?('/importer/run')
+          raise 'import did not converge' if request_times.size > rows + 10
+        end
+
+        created = Issue.count - issues_before
+        assert_equal rows, created, "expected #{rows} issues to be created for #{variant}/#{rows}"
+        puts format('%-14s %8d %9d %9.2f %10.3f %10.3f %12d %8d',
+                    variant, rows, request_times.size, request_times.sum,
+                    request_times.max, request_times.sum / request_times.size,
+                    total_queries, created)
+      end
+    end
+  end
+
+  private
+
+  def measure
+    queries = 0
+    subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
+      queries += 1 unless payload[:name] == 'SCHEMA' || payload[:cached]
+    end
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    yield
+    [Process.clock_gettime(Process::CLOCK_MONOTONIC) - started, queries]
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber)
+  end
+
+  def bench_params(iip, variant)
+    fields_map = {
+      '#' => 'standard_field-id',
+      'Subject' => 'standard_field-subject',
+      'Description' => 'standard_field-description',
+      'Priority' => 'standard_field-priority',
+      'Tracker' => 'standard_field-tracker',
+      'Status' => 'standard_field-status'
+    }
+    fields_map['Tags'] = 'custom_field-Tags' if %i[custom_fields full].include?(variant)
+    fields_map['Parent'] = 'standard_field-parent_issue' if %i[parent full].include?(variant)
+
+    {
+      import_timestamp: iip.created.strftime('%Y-%m-%d %H:%M:%S'),
+      unique_field: '#',
+      project_id: @project.identifier,
+      fields_map: fields_map
+    }
+  end
+
+  def create_iip!(csv_data)
+    ImportInProgress.where(user_id: @user.id).delete_all
+    iip = ImportInProgress.new
+    iip.user = @user
+    iip.csv_data = csv_data
+    iip.created = DateTime.now
+    iip.encoding = 'UTF-8'
+    iip.col_sep = ','
+    iip.quote_char = '"'
+    iip.save!
+    iip
+  end
+
+  def create_user!(role, project)
+    user = User.new admin: true,
+                    firstname: 'Bench',
+                    lastname: 'User',
+                    mail: 'bench.user@example.com'
+    user.login = 'bench'
+    membership = user.memberships.build(project: project)
+    membership.roles << role
+    membership.principal = user
+    user.pref.auto_watch_on = nil if Redmine::VERSION.to_s.to_f >= 5.1
+    user.save!
+    user
+  end
+
+  def create_tags_field!(project, tracker)
+    field = IssueCustomField.new name: 'Tags', multiple: true, field_format: 'list'
+    field.projects << project
+    field.possible_values = %w[tag1 tag2]
+    field.save!
+    tracker.custom_fields << field
+    tracker.save!
+    field
+  end
+end


### PR DESCRIPTION
## Problem

Importing a large CSV file processed every row synchronously in a single request (`ImporterController#result`). With thousands of rows a single request easily exceeds typical reverse-proxy timeouts, and the import fails.

Measured on Redmine 6.1.3 / PostgreSQL (local, test env):

| variant | rows | single-request time (before) |
|---|---:|---:|
| standard fields only | 5,000 | **85.6 s** |
| + multi-value CF + parent forward refs | 1,000 | **151 s** |
| + multi-value CF + parent forward refs | 5,000 | aborted (~540 rows after 60 min) |

## Solution

Follow the design of Redmine core's `ImportsController` (5 items / 10 seconds per request, client-driven polling):

- `POST result` now only validates and stores the mapping settings on `ImportInProgress`, then redirects to a progress page
- Each `POST run` imports at most 5 rows or 10 seconds, then responds with a redirect (HTML) or a self-recursive ajax snippet (JS), until every row is consumed
- Progress, counters, failed rows, the unique-value-to-issue mapping and unresolved forward references (deferred parent/relation callbacks) are persisted on `ImportInProgress` as JSON; each request resumes from the stored position, so parent issues defined in a later batch are still resolved
- Failed rows advance the position and are never retried, matching core's behavior
- Re-submitting the mapping form no longer restarts a started import (the legacy code guaranteed this by deleting the iip after importing)

### After

| variant | rows | requests | total | **max per request** |
|---|---:|---:|---:|---:|
| standard fields only | 5,000 | 1,000 | 92.0 s | **0.28 s** |
| + CF + parent refs | 1,000 | 200 | 54.6 s | **0.54 s** |
| + CF + parent refs | 5,000 | 1,000 | 284 s | **0.75 s** |

Every request stays well under the 10-second budget, so the import survives any reasonable proxy timeout. Total time overhead is +7.5% for the simple case, and the CF + parent case actually got faster (the superlinear per-row degradation disappeared).

## Notes for reviewers

- Migration required: `bundle exec rake redmine:plugins:migrate` (adds `settings` / `total_items` / `position` / `finished` to `import_in_progresses`)
- The per-row import logic (`import_row`) is moved from the old loop unchanged; the diff is large but mostly mechanical
- Existing functional tests are migrated to a `run_import_to_completion` helper; new acceptance tests cover batch splitting/resuming, resolving parents across batch boundaries, failed-row handling and the duplicate-submit guard (55 runs, 225 assertions, all green)
- `test/performance/` contains a CSV generator and a benchmark (source of the numbers above); it is intentionally outside the directories collected by `rake redmine:plugins:test` and CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)