### PR TITLE
unique field 検索が無効な IssueQuery フィルタで全チケット検索に化ける問題を修正

### DIFF
--- a/app/controllers/importer_controller.rb
+++ b/app/controllers/importer_controller.rb
@@ -5,6 +5,7 @@ require 'tempfile'
 
 MultipleIssuesForUniqueValue = Class.new(RuntimeError)
 NoIssueForUniqueValue = Class.new(RuntimeError)
+UnsupportedUniqueField = Class.new(RuntimeError)
 
 class ImporterController < ApplicationController
   using RedmineImporter::Patches::Redmine51ToFsMethodPatch
@@ -305,6 +306,8 @@ class ImporterController < ApplicationController
             @deferred_callbacks.register(other_value, :add_relation, row[unique_field], rtype)
           rescue MultipleIssuesForUniqueValue
             @messages << "Warning: Multiple matches for relation target '#{other_value}'"
+          rescue UnsupportedUniqueField
+            @messages << l(:warning_unique_field_not_supported, attr: unique_field)
           end
         end
 
@@ -345,8 +348,10 @@ class ImporterController < ApplicationController
     # translate unique_attr if it's a custom field -- only on the first issue
     unless unique_attr_checked
       if unique_field && !ISSUE_ATTRS.include?(unique_attr.to_sym)
+        # fields_map values carry a 'custom_field-' prefix (see #match)
+        cf_name = unique_attr.delete_prefix('custom_field-')
         issue.available_custom_fields.each do |cf|
-          if cf.name == unique_attr
+          if cf.name == cf_name
             unique_attr = "cf_#{cf.id}"
             break
           end
@@ -396,6 +401,9 @@ class ImporterController < ApplicationController
         log_failure(row,
                     l(:warning_multiple_matches_for_update, issue_num: @failed_count + 1,
                                                             value: row[unique_field]))
+        raise RowFailed
+      rescue UnsupportedUniqueField
+        log_failure(row, l(:warning_unique_field_not_supported, attr: unique_field))
         raise RowFailed
       end
     end
@@ -497,6 +505,9 @@ class ImporterController < ApplicationController
     @failed_count += 1
     @failed_issues[@failed_count] = row
     @messages << l(:warning_parent_multiple_matches, issue_num: @failed_count, value: parent_value)
+    raise RowFailed
+  rescue UnsupportedUniqueField
+    log_failure(row, l(:warning_unique_field_not_supported, attr: unique_field))
     raise RowFailed
   end
 
@@ -744,7 +755,11 @@ class ImporterController < ApplicationController
 
       query = query_class.new(name: '_importer', project: @project)
       query.add_filter('status_id', '*', [1])
-      query.add_filter(unique_attr, '=', [attr_value])
+      # add_filter silently ignores invalid filter names (returning nil), which
+      # would turn the query into an unfiltered "all issues" search
+      if query.add_filter(query_filter_for_unique_attr(unique_attr), '=', [attr_value]).nil?
+        raise UnsupportedUniqueField, "'#{unique_attr}' is not a valid IssueQuery filter"
+      end
 
       issues = Issue.joins([:project])
                     .includes(%i[assigned_to status tracker project priority
@@ -764,6 +779,18 @@ class ImporterController < ApplicationController
       raise NoIssueForUniqueValue, "No issue with #{unique_attr} of '#{attr_value}' found"
     else
       issues.first
+    end
+  end
+
+  # Maps a unique_attr from fields_map to a valid IssueQuery filter name.
+  # Custom fields are already translated to 'cf_<id>' by translate_unique_attr.
+  # Other standard fields (tracker, priority, ...) would require translating
+  # names to ids, so they are left as-is and rejected by the add_filter guard.
+  def query_filter_for_unique_attr(unique_attr)
+    case unique_attr
+    when 'standard_field-id' then 'issue_id'
+    when 'standard_field-subject' then 'subject'
+    else unique_attr
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,4 +67,5 @@ en:
   warning_watcher_not_found: "Warning: When trying to add watchers on issue %{issue_num} below, User %{login} was not found"
   warning_custom_field_invalid: "Warning: When trying to set custom field %{field_name} on issue %{issue_num} below, value %{value} was invalid"
   warning_duplicate_unique_value: "Warning: Unique field %{attr} with value '%{value}' in issue %{issue_num} has duplicate record"
+  warning_unique_field_not_supported: "Warning: The unique field %{attr} cannot be used to find existing issues. Use # (ID), Subject, or a custom field that is used as a filter."
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -68,3 +68,4 @@ ja:
   warning_watcher_not_found: "警告: チケット %{issue_num} のウォッチャー追加時に、ユーザー %{login} が見つかりませんでした。"
   warning_custom_field_invalid: "警告: チケット %{issue_num} のカスタムフィールド %{field_name} に、値 %{value} は無効です。"
   warning_duplicate_unique_value: "警告: チケット %{issue_num} の %{attr} の値 '%{value}' はすでに存在します。"
+  warning_unique_field_not_supported: "警告: ユニークフィールド %{attr} ではチケットを検索できません。#（ID）、題名、または「フィルタとして使用」が有効なカスタムフィールドを指定してください。"

--- a/test/functional/importer_controller_test.rb
+++ b/test/functional/importer_controller_test.rb
@@ -709,6 +709,77 @@ class ImporterControllerTest < ActionController::TestCase
     end
   end
 
+  test 'should update only the matching issue when unique field is Subject and multiple open issues exist' do
+    other1 = create_issue!(@project, @user, { subject: 'unrelated one' })
+    other2 = create_issue!(@project, @user, { subject: 'unrelated two' })
+    @iip.update!(csv_data: "Subject,Start date\nfoobar,2030-01-15\n")
+    post :result, params: build_params(update_issue: 'true', unique_field: 'Subject').tap { |params|
+                            params[:fields_map]['Start date'] = 'standard_field-start_date'
+                          }
+    assert_response :success
+    assert_equal Date.new(2030, 1, 15), @issue.reload.start_date
+    assert_not_equal Date.new(2030, 1, 15), other1.reload.start_date
+    assert_not_equal Date.new(2030, 1, 15), other2.reload.start_date
+  end
+
+  test 'should update only the issue with matching id when unique field is # and use_issue_id is off' do
+    other = create_issue!(@project, @user, { subject: 'unrelated' })
+    @iip.update!(csv_data: "#,Subject\n#{@issue.id},renamed by import\n")
+    post :result, params: build_params(update_issue: 'true')
+    assert_response :success
+    assert_equal 'renamed by import', @issue.reload.subject
+    assert_equal 'unrelated', other.reload.subject
+  end
+
+  test 'should not update an unrelated issue when the unique value matches nothing' do
+    @iip.update!(csv_data: "Subject,Start date\nno such subject,2030-01-15\n")
+    post :result, params: build_params(update_issue: 'true', unique_field: 'Subject').tap { |params|
+                            params[:fields_map]['Start date'] = 'standard_field-start_date'
+                          }
+    assert_response :success
+    assert_equal 'foobar', @issue.reload.subject
+    assert_not_equal Date.new(2030, 1, 15), @issue.start_date
+    assert response.body.include?('no match for the value')
+  end
+
+  test 'should resolve parent by subject when multiple open issues exist' do
+    create_issue!(@project, @user, { subject: 'unrelated one' })
+    @iip.update!(csv_data: "Subject,Tracker,Status,Priority,Parent\nchild by subject,Defect,New,Critical,foobar\n")
+    post :result, params: build_params(unique_field: 'Subject')
+    assert_response :success
+    child = Issue.find_by!(subject: 'child by subject')
+    assert_equal @issue.id, child.parent_id
+  end
+
+  test 'should update the issue found by custom field unique value' do
+    ref_field = IssueCustomField.create!(name: 'RefNo', field_format: 'string',
+                                         is_filter: true, projects: [@project],
+                                         trackers: [@tracker])
+    @issue.reload
+    @issue.custom_field_values = { ref_field.id => 'REF-1' }
+    @issue.save!
+    other = create_issue!(@project, @user, { subject: 'other with ref', tracker: @tracker }).reload
+    other.custom_field_values = { ref_field.id => 'REF-2' }
+    other.save!
+    @iip.update!(csv_data: "RefNo,Subject,Tracker\nREF-2,renamed via cf,Defect\n")
+    post :result, params: build_params(update_issue: 'true', unique_field: 'RefNo').tap { |params|
+                            params[:fields_map]['RefNo'] = 'custom_field-RefNo'
+                          }
+    assert_response :success
+    assert_equal 'renamed via cf', other.reload.subject
+    assert_equal 'foobar', @issue.reload.subject
+  end
+
+  test 'should fail the row with a clear error when unique field cannot be used for lookup' do
+    create_issue!(@project, @user, { subject: 'unrelated one' })
+    @iip.update!(csv_data: "Priority,Subject\nCritical,should not be applied\n")
+    post :result, params: build_params(update_issue: 'true', unique_field: 'Priority')
+    assert_response :success
+    assert_equal 'foobar', @issue.reload.subject
+    assert_nil Issue.find_by(subject: 'should not be applied')
+    assert response.body.include?('cannot be used to find existing issues')
+  end
+
   protected
 
   def build_params(opts = {})


### PR DESCRIPTION
## チケット

https://insidemine.agileware.jp/issues/116671

## 問題

`ImporterController#issue_for_unique_attr` は unique field で既存チケットを検索する際、fields_map の値（`standard_field-id`, `standard_field-subject`, `custom_field-<名前>`）をそのまま `IssueQuery#add_filter` に渡していた。これらは IssueQuery の有効なフィルタ名ではなく、`add_filter` は無効なフィルタ名を **nil を返して黙って無視する**ため、検索クエリが「全チケット検索」に化けていた。

その結果:

- DB 上のオープンチケットがちょうど1件 → unique 値と無関係に**その1件が誤ってヒット**（更新モードなら誤更新）
- 2件以上 → `MultipleIssuesForUniqueValue` により「Unique field に重複がある」という**誤解を招くエラー**で行が失敗

既存テストは DB にオープンチケットが1件しかない状態で実行されるため、偶然パスしていた。

また、チケット起票時は「カスタムフィールドの unique field は影響なし」と判断していたが、実際には `translate_unique_attr` が `custom_field-` プレフィックス付きの値と素の CF 名を比較しており変換が効かず、**CF unique も同じバグを踏んでいた**（プレフィックスを導入した 863956c 以降）。

## 修正内容

1. `standard_field-id` / `standard_field-subject` を IssueQuery の有効なフィルタ名 `issue_id` / `subject` に変換する `query_filter_for_unique_attr` を追加
2. `translate_unique_attr` で `custom_field-` プレフィックスを剥がしてから CF 名と比較し、`cf_<id>` への変換を復活
3. 再発防止として、`add_filter` が nil を返した場合は新例外 `UnsupportedUniqueField` を raise し、3つの呼び出し系統（更新・親チケット・リレーション）それぞれで明確な行エラーとして報告（tracker / priority 等は名前→ID の値変換が必要になるため意図的に非サポートとし、エラーメッセージで案内する）

## テスト

テストファーストで実装（1コミット目が red テスト、2コミット目で green）。

- オープンチケット複数存在下での「題名」による更新
- `use_issue_id` OFF での「#」による更新
- 一致なしの unique 値で無関係チケットが誤更新されないこと（バグの直接再現）
- 題名による親チケット解決
- カスタムフィールド unique による更新
- 検索に使えない unique field の明確な行エラー

```
bundle exec rake redmine:plugins:test NAME=redmine_importer RAILS_ENV=test
55 runs, 198 assertions, 0 failures, 0 errors, 0 skips
```

（Redmine 6.1.3 + PostgreSQL で確認）

## 補足

- #51 (batch-import) とは git 上のコンフリクトなし。ただし #51 はテストを `run_import_to_completion` ヘルパーに書き換えているため、#51 マージ後は本 PR の新規テスト6件を同ヘルパー流儀に合わせる必要がある（逆順でマージする場合も同様）

🤖 Generated with [Claude Code](https://claude.com/claude-code)