### PR TITLE
Fix unique field lookup matching every open issue via invalid IssueQuery filter

### DIFF
--- a/app/controllers/importer_controller.rb
+++ b/app/controllers/importer_controller.rb
@@ -5,6 +5,7 @@ require 'tempfile'
 
 MultipleIssuesForUniqueValue = Class.new(RuntimeError)
 NoIssueForUniqueValue = Class.new(RuntimeError)
+UnsupportedUniqueField = Class.new(RuntimeError)
 
 class ImporterController < ApplicationController
   using RedmineImporter::Patches::Redmine51ToFsMethodPatch
@@ -305,6 +306,8 @@ class ImporterController < ApplicationController
             @deferred_callbacks.register(other_value, :add_relation, row[unique_field], rtype)
           rescue MultipleIssuesForUniqueValue
             @messages << "Warning: Multiple matches for relation target '#{other_value}'"
+          rescue UnsupportedUniqueField
+            @messages << l(:warning_unique_field_not_supported, attr: unique_field)
           end
         end
 
@@ -345,8 +348,10 @@ class ImporterController < ApplicationController
     # translate unique_attr if it's a custom field -- only on the first issue
     unless unique_attr_checked
       if unique_field && !ISSUE_ATTRS.include?(unique_attr.to_sym)
+        # fields_map values carry a 'custom_field-' prefix (see #match)
+        cf_name = unique_attr.delete_prefix('custom_field-')
         issue.available_custom_fields.each do |cf|
-          if cf.name == unique_attr
+          if cf.name == cf_name
             unique_attr = "cf_#{cf.id}"
             break
           end
@@ -396,6 +401,9 @@ class ImporterController < ApplicationController
         log_failure(row,
                     l(:warning_multiple_matches_for_update, issue_num: @failed_count + 1,
                                                             value: row[unique_field]))
+        raise RowFailed
+      rescue UnsupportedUniqueField
+        log_failure(row, l(:warning_unique_field_not_supported, attr: unique_field))
         raise RowFailed
       end
     end
@@ -497,6 +505,9 @@ class ImporterController < ApplicationController
     @failed_count += 1
     @failed_issues[@failed_count] = row
     @messages << l(:warning_parent_multiple_matches, issue_num: @failed_count, value: parent_value)
+    raise RowFailed
+  rescue UnsupportedUniqueField
+    log_failure(row, l(:warning_unique_field_not_supported, attr: unique_field))
     raise RowFailed
   end
 
@@ -744,7 +755,11 @@ class ImporterController < ApplicationController
 
       query = query_class.new(name: '_importer', project: @project)
       query.add_filter('status_id', '*', [1])
-      query.add_filter(unique_attr, '=', [attr_value])
+      # add_filter silently ignores invalid filter names (returning nil), which
+      # would turn the query into an unfiltered "all issues" search
+      if query.add_filter(query_filter_for_unique_attr(unique_attr), '=', [attr_value]).nil?
+        raise UnsupportedUniqueField, "'#{unique_attr}' is not a valid IssueQuery filter"
+      end
 
       issues = Issue.joins([:project])
                     .includes(%i[assigned_to status tracker project priority
@@ -764,6 +779,18 @@ class ImporterController < ApplicationController
       raise NoIssueForUniqueValue, "No issue with #{unique_attr} of '#{attr_value}' found"
     else
       issues.first
+    end
+  end
+
+  # Maps a unique_attr from fields_map to a valid IssueQuery filter name.
+  # Custom fields are already translated to 'cf_<id>' by translate_unique_attr.
+  # Other standard fields (tracker, priority, ...) would require translating
+  # names to ids, so they are left as-is and rejected by the add_filter guard.
+  def query_filter_for_unique_attr(unique_attr)
+    case unique_attr
+    when 'standard_field-id' then 'issue_id'
+    when 'standard_field-subject' then 'subject'
+    else unique_attr
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,4 +67,5 @@ en:
   warning_watcher_not_found: "Warning: When trying to add watchers on issue %{issue_num} below, User %{login} was not found"
   warning_custom_field_invalid: "Warning: When trying to set custom field %{field_name} on issue %{issue_num} below, value %{value} was invalid"
   warning_duplicate_unique_value: "Warning: Unique field %{attr} with value '%{value}' in issue %{issue_num} has duplicate record"
+  warning_unique_field_not_supported: "Warning: The unique field %{attr} cannot be used to find existing issues. Use # (ID), Subject, or a custom field that is used as a filter."
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -68,3 +68,4 @@ ja:
   warning_watcher_not_found: "警告: チケット %{issue_num} のウォッチャー追加時に、ユーザー %{login} が見つかりませんでした。"
   warning_custom_field_invalid: "警告: チケット %{issue_num} のカスタムフィールド %{field_name} に、値 %{value} は無効です。"
   warning_duplicate_unique_value: "警告: チケット %{issue_num} の %{attr} の値 '%{value}' はすでに存在します。"
+  warning_unique_field_not_supported: "警告: ユニークフィールド %{attr} ではチケットを検索できません。#（ID）、題名、または「フィルタとして使用」が有効なカスタムフィールドを指定してください。"

--- a/test/functional/importer_controller_test.rb
+++ b/test/functional/importer_controller_test.rb
@@ -709,6 +709,77 @@ class ImporterControllerTest < ActionController::TestCase
     end
   end
 
+  test 'should update only the matching issue when unique field is Subject and multiple open issues exist' do
+    other1 = create_issue!(@project, @user, { subject: 'unrelated one' })
+    other2 = create_issue!(@project, @user, { subject: 'unrelated two' })
+    @iip.update!(csv_data: "Subject,Start date\nfoobar,2030-01-15\n")
+    post :result, params: build_params(update_issue: 'true', unique_field: 'Subject').tap { |params|
+                            params[:fields_map]['Start date'] = 'standard_field-start_date'
+                          }
+    assert_response :success
+    assert_equal Date.new(2030, 1, 15), @issue.reload.start_date
+    assert_not_equal Date.new(2030, 1, 15), other1.reload.start_date
+    assert_not_equal Date.new(2030, 1, 15), other2.reload.start_date
+  end
+
+  test 'should update only the issue with matching id when unique field is # and use_issue_id is off' do
+    other = create_issue!(@project, @user, { subject: 'unrelated' })
+    @iip.update!(csv_data: "#,Subject\n#{@issue.id},renamed by import\n")
+    post :result, params: build_params(update_issue: 'true')
+    assert_response :success
+    assert_equal 'renamed by import', @issue.reload.subject
+    assert_equal 'unrelated', other.reload.subject
+  end
+
+  test 'should not update an unrelated issue when the unique value matches nothing' do
+    @iip.update!(csv_data: "Subject,Start date\nno such subject,2030-01-15\n")
+    post :result, params: build_params(update_issue: 'true', unique_field: 'Subject').tap { |params|
+                            params[:fields_map]['Start date'] = 'standard_field-start_date'
+                          }
+    assert_response :success
+    assert_equal 'foobar', @issue.reload.subject
+    assert_not_equal Date.new(2030, 1, 15), @issue.start_date
+    assert response.body.include?('no match for the value')
+  end
+
+  test 'should resolve parent by subject when multiple open issues exist' do
+    create_issue!(@project, @user, { subject: 'unrelated one' })
+    @iip.update!(csv_data: "Subject,Tracker,Status,Priority,Parent\nchild by subject,Defect,New,Critical,foobar\n")
+    post :result, params: build_params(unique_field: 'Subject')
+    assert_response :success
+    child = Issue.find_by!(subject: 'child by subject')
+    assert_equal @issue.id, child.parent_id
+  end
+
+  test 'should update the issue found by custom field unique value' do
+    ref_field = IssueCustomField.create!(name: 'RefNo', field_format: 'string',
+                                         is_filter: true, projects: [@project],
+                                         trackers: [@tracker])
+    @issue.reload
+    @issue.custom_field_values = { ref_field.id => 'REF-1' }
+    @issue.save!
+    other = create_issue!(@project, @user, { subject: 'other with ref', tracker: @tracker }).reload
+    other.custom_field_values = { ref_field.id => 'REF-2' }
+    other.save!
+    @iip.update!(csv_data: "RefNo,Subject,Tracker\nREF-2,renamed via cf,Defect\n")
+    post :result, params: build_params(update_issue: 'true', unique_field: 'RefNo').tap { |params|
+                            params[:fields_map]['RefNo'] = 'custom_field-RefNo'
+                          }
+    assert_response :success
+    assert_equal 'renamed via cf', other.reload.subject
+    assert_equal 'foobar', @issue.reload.subject
+  end
+
+  test 'should fail the row with a clear error when unique field cannot be used for lookup' do
+    create_issue!(@project, @user, { subject: 'unrelated one' })
+    @iip.update!(csv_data: "Priority,Subject\nCritical,should not be applied\n")
+    post :result, params: build_params(update_issue: 'true', unique_field: 'Priority')
+    assert_response :success
+    assert_equal 'foobar', @issue.reload.subject
+    assert_nil Issue.find_by(subject: 'should not be applied')
+    assert response.body.include?('cannot be used to find existing issues')
+  end
+
   protected
 
   def build_params(opts = {})


### PR DESCRIPTION
## Problem

`ImporterController#issue_for_unique_attr` passed fields_map values (`standard_field-id`, `standard_field-subject`, `custom_field-<name>`) directly to `IssueQuery#add_filter`. These are not valid IssueQuery filter names, and `add_filter` **silently ignores invalid filter names (returning nil)**, so the lookup query degraded to an unfiltered "all issues" search.

As a result:

- With exactly one open issue in the DB, **that issue was matched regardless of the unique value** (wrongly updated in update mode)
- With two or more, every row failed with a misleading `MultipleIssuesForUniqueValue` ("duplicate unique field") error

Existing tests never caught this because their DB holds a single open issue, which makes the degraded query accidentally return the right one.

Additionally, although the ticket initially assumed custom-field unique keys were unaffected, `translate_unique_attr` compared the prefixed value (`custom_field-<name>`) against the bare CF name, so the `cf_<id>` translation never happened — **custom field unique keys hit the same bug** (broken since 863956c introduced the prefix).

## Changes

1. Add `query_filter_for_unique_attr` to map `standard_field-id` / `standard_field-subject` to the valid filter names `issue_id` / `subject`
2. Strip the `custom_field-` prefix in `translate_unique_attr` so custom field unique keys resolve to `cf_<id>` again
3. As a regression guard, raise a new `UnsupportedUniqueField` error when `add_filter` rejects the filter name, and report it as a clear per-row error in all three call paths (issue update, parent lookup, relation lookup). Other standard fields (tracker, priority, ...) are intentionally unsupported since they would require name-to-id value translation; the error message guides the user.

## Tests

Written test-first (the first commit adds red tests, the second turns them green):

- Update by Subject with multiple open issues present
- Update by `#` with `use_issue_id` off
- A non-matching unique value must not update an unrelated issue (direct reproduction of the bug)
- Parent resolution by Subject
- Update via a custom field unique key
- A clear per-row error when the unique field cannot be used for lookup

```
bundle exec rake redmine:plugins:test NAME=redmine_importer RAILS_ENV=test
55 runs, 198 assertions, 0 failures, 0 errors, 0 skips
```

(Verified on Redmine 6.1.3 + PostgreSQL)

## Notes

- No git conflicts with #51 (batch-import). However, #51 rewrites the functional tests to use the `run_import_to_completion` helper, so whichever lands second needs the 6 new tests here adapted to that style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)