### PR TITLE
fix: Reject import progress and batch requests from another project's URL

### DIFF
--- a/app/controllers/importer_controller.rb
+++ b/app/controllers/importer_controller.rb
@@ -35,12 +35,12 @@ class ImporterController < ApplicationController
     end
 
     # Delete existing iip to ensure there can't be two iips for a user
-    ImportInProgress.where('user_id = ?', User.current.id).delete_all
-    # save import-in-progress data
-    iip = ImportInProgress.find_or_create_by(user_id: User.current.id)
-    # Remember the project the import was started on; run/result requests
-    # for any other project must not see or resume this import (#117121).
-    iip.project = @project
+    # within the same project; imports the user has in progress on other
+    # projects are independent and must not be discarded (#117121)
+    ImportInProgress.where(user_id: User.current.id, project_id: @project.id).delete_all
+    # save import-in-progress data, keyed by user and originating project;
+    # run/result requests for any other project must not see or resume it
+    iip = ImportInProgress.find_or_create_by(user_id: User.current.id, project_id: @project.id)
     iip.quote_char = params[:wrapper]
     iip.col_sep = params[:splitter]
     iip.encoding = params[:encoding]

--- a/app/controllers/importer_controller.rb
+++ b/app/controllers/importer_controller.rb
@@ -374,6 +374,7 @@ class ImporterController < ApplicationController
     # once it finished (#117120).
     if iip.settings.present?
       if iip.finished?
+        flash[:notice] = l(:notice_import_already_finished)
         redirect_to project_importer_result_path(project_id: @project)
       else
         flash[:notice] = l(:notice_import_already_running)

--- a/app/controllers/importer_controller.rb
+++ b/app/controllers/importer_controller.rb
@@ -9,6 +9,10 @@ NoIssueForUniqueValue = Class.new(RuntimeError)
 class ImporterController < ApplicationController
   using RedmineImporter::Patches::Redmine51ToFsMethodPatch
   before_action :find_project
+  # Every action requires the :import permission on the URL's project (the
+  # importer module must be enabled there and the role must allow it), like
+  # Redmine core's project-scoped controllers.
+  before_action :authorize
 
   ISSUE_ATTRS = %i[id subject assigned_to fixed_version
                    author description category priority tracker status
@@ -34,6 +38,9 @@ class ImporterController < ApplicationController
     ImportInProgress.where('user_id = ?', User.current.id).delete_all
     # save import-in-progress data
     iip = ImportInProgress.find_or_create_by(user_id: User.current.id)
+    # Remember the project the import was started on; run/result requests
+    # for any other project must not see or resume this import (#117121).
+    iip.project = @project
     iip.quote_char = params[:wrapper]
     iip.col_sep = params[:splitter]
     iip.encoding = params[:encoding]
@@ -347,7 +354,7 @@ class ImporterController < ApplicationController
     init_display_state
 
     # Retrieve saved import data
-    iip = ImportInProgress.find_by_user_id(User.current.id)
+    iip = current_import_in_progress
     if iip.nil?
       flash[:error] = l(:error_no_import_in_progress)
       return
@@ -423,7 +430,7 @@ class ImporterController < ApplicationController
 
   # GET run
   def show_run_page
-    @iip = ImportInProgress.find_by_user_id(User.current.id)
+    @iip = current_import_in_progress
     if @iip.nil? || @iip.settings.blank?
       flash[:error] = l(:error_no_import_in_progress)
       redirect_to project_importer_path(project_id: @project)
@@ -434,7 +441,7 @@ class ImporterController < ApplicationController
 
   # POST run
   def process_batch
-    @iip = ImportInProgress.find_by_user_id(User.current.id)
+    @iip = current_import_in_progress
     if @iip.nil? || @iip.settings.blank?
       flash[:error] = l(:error_no_import_in_progress)
       return redirect_to project_importer_path(project_id: @project)
@@ -490,7 +497,7 @@ class ImporterController < ApplicationController
   def show_result
     init_display_state
 
-    iip = ImportInProgress.find_by_user_id(User.current.id)
+    iip = current_import_in_progress
     if iip.nil? || iip.settings.blank?
       flash.now[:error] = l(:error_no_import_in_progress)
       return
@@ -861,6 +868,16 @@ class ImporterController < ApplicationController
 
   def find_project
     @project = Project.find(params[:project_id])
+  end
+
+  # The import the current user started on the current project. Scoping by
+  # project (in addition to user) makes an import invisible from any other
+  # project's URL: the batch target project is derived from the URL, so a
+  # stale tab on a foreign project would otherwise import the remaining rows
+  # into that unrelated project (#117121). A mismatch behaves exactly like
+  # "no import in progress".
+  def current_import_in_progress
+    ImportInProgress.find_by(user_id: User.current.id, project_id: @project.id)
   end
 
   def flash_message(type, text)

--- a/app/controllers/importer_controller.rb
+++ b/app/controllers/importer_controller.rb
@@ -365,9 +365,20 @@ class ImporterController < ApplicationController
     end
     # A mapping form may only be submitted once per uploaded file (the legacy
     # implementation guaranteed this by deleting the iip after importing);
-    # re-submitting would restart the import and duplicate issues.
+    # re-submitting would restart the import and duplicate issues. The
+    # timestamp matched above, so this is the form of the import the user
+    # already started (typically the browser's back button from the progress
+    # page): send them back to that import instead of failing with the
+    # misleading "superseded" error — to the progress page while it is
+    # running, so polling resumes from the saved position, or to its report
+    # once it finished (#117120).
     if iip.settings.present?
-      flash[:error] = l(:error_import_superseded)
+      if iip.finished?
+        redirect_to project_importer_result_path(project_id: @project)
+      else
+        flash[:notice] = l(:notice_import_already_running)
+        redirect_to project_importer_run_path(project_id: @project)
+      end
       return
     end
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -43,6 +43,7 @@ de:
     label_importer_use_issue_id: "Import using issue ids"
     error_no_import_in_progress: "No import is currently in progress"
     error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
+    notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
     error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
     error_issue_id_taken: "This issue id has already been taken."
     error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -44,6 +44,7 @@ de:
     error_no_import_in_progress: "No import is currently in progress"
     error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
     notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
+    notice_import_already_finished: "The import you submitted has already finished, so its report is shown. No rows were imported again."
     error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
     error_issue_id_taken: "This issue id has already been taken."
     error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,7 @@ en:
 
   error_no_import_in_progress: "No import is currently in progress"
   error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
+  notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
   error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
   error_issue_id_taken: "This issue id has already been taken."
   error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,6 +52,7 @@ en:
   error_no_import_in_progress: "No import is currently in progress"
   error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
   notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
+  notice_import_already_finished: "The import you submitted has already finished, so its report is shown. No rows were imported again."
   error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
   error_issue_id_taken: "This issue id has already been taken."
   error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -53,6 +53,7 @@ ja:
   error_no_import_in_progress: "現在進行中のインポートがありません。"
   error_import_superseded: "このインポートは別のインポートにより無効になりました。"
   notice_import_already_running: "実行中のインポートがあるため進捗画面を表示しています。残りの行は引き続き取り込まれます。"
+  notice_import_already_finished: "送信されたインポートは既に完了しているため、結果画面を表示しています。行が再度取り込まれることはありません。"
   error_must_map_id_column: "チケットIDを使用してインポートする場合、対応するIDの列を指定してください。"
   error_issue_id_taken: "このチケットIDは既に使用されています。"
   error_csv_no_data: "CSVにデータ行がありません。ファイルのエンコーディングを確認してください。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -52,6 +52,7 @@ ja:
 
   error_no_import_in_progress: "現在進行中のインポートがありません。"
   error_import_superseded: "このインポートは別のインポートにより無効になりました。"
+  notice_import_already_running: "実行中のインポートがあるため進捗画面を表示しています。残りの行は引き続き取り込まれます。"
   error_must_map_id_column: "チケットIDを使用してインポートする場合、対応するIDの列を指定してください。"
   error_issue_id_taken: "このチケットIDは既に使用されています。"
   error_csv_no_data: "CSVにデータ行がありません。ファイルのエンコーディングを確認してください。"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -41,6 +41,7 @@ pt-BR:
   error_no_import_in_progress: "No import is currently in progress"
   error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
   notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
+  notice_import_already_finished: "The import you submitted has already finished, so its report is shown. No rows were imported again."
   error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
   error_issue_id_taken: "This issue id has already been taken."
   error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -40,6 +40,7 @@ pt-BR:
   label_importer_use_issue_id: "Import using issue ids"
   error_no_import_in_progress: "No import is currently in progress"
   error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
+  notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
   error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
   error_issue_id_taken: "This issue id has already been taken."
   error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -43,6 +43,7 @@ ru:
   label_importer_use_issue_id: "Import using issue ids"
   error_no_import_in_progress: "No import is currently in progress"
   error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
+  notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
   error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
   error_issue_id_taken: "This issue id has already been taken."
   error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -44,6 +44,7 @@ ru:
   error_no_import_in_progress: "No import is currently in progress"
   error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
   notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
+  notice_import_already_finished: "The import you submitted has already finished, so its report is shown. No rows were imported again."
   error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
   error_issue_id_taken: "This issue id has already been taken."
   error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -44,6 +44,7 @@ zh:
   label_importer_use_issue_id: "Import using issue ids"
   error_no_import_in_progress: "No import is currently in progress"
   error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
+  notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
   error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
   error_issue_id_taken: "This issue id has already been taken."
   error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -45,6 +45,7 @@ zh:
   error_no_import_in_progress: "No import is currently in progress"
   error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
   notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
+  notice_import_already_finished: "The import you submitted has already finished, so its report is shown. No rows were imported again."
   error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
   error_issue_id_taken: "This issue id has already been taken."
   error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/db/migrate/003_add_project_to_import_in_progresses.rb
+++ b/db/migrate/003_add_project_to_import_in_progresses.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddProjectToImportInProgresses < ActiveRecord::Migration[6.1]
+  def change
+    # The project the import was started on. run/result requests whose URL
+    # points at a different project are rejected, so a stale tab cannot
+    # import the remaining rows into an unrelated project (#117121).
+    add_column :import_in_progresses, :project_id, :integer
+  end
+end

--- a/init.rb
+++ b/init.rb
@@ -17,7 +17,9 @@ Redmine::Plugin.register :redmine_importer do
            partial: 'settings/redmine_importer_settings'
 
   project_module :importer do
-    permission :import, importer: :index
+    # Every action must be declared here so that ImporterController's
+    # `authorize` filter can also protect the result/run pages (#117121).
+    permission :import, importer: %i[index match result run]
   end
   menu :project_menu,
        :importer,

--- a/test/functional/importer_controller_test.rb
+++ b/test/functional/importer_controller_test.rb
@@ -1228,9 +1228,10 @@ class ImporterControllerTest < ActionController::TestCase
     create_iip!('CustomFieldMultiValues', user, project)
   end
 
-  def create_iip!(filename, user, _project)
+  def create_iip!(filename, user, project)
     iip = ImportInProgress.new
     iip.user = user
+    iip.project = project
     iip.csv_data = get_csv(filename)
     # iip.created = DateTime.new(2001,2,3,4,5,6,'+7')
     iip.created = DateTime.now

--- a/test/functional/importer_controller_test.rb
+++ b/test/functional/importer_controller_test.rb
@@ -1001,6 +1001,8 @@ class ImporterControllerTest < ActionController::TestCase
     assert_redirected_to "/projects/#{@project.identifier}/importer/result"
     assert_nil flash[:error],
                'a resubmitted form of a finished import must not show an error'
+    assert_equal I18n.t(:notice_import_already_finished), flash[:notice],
+                 'the user must be told the shown report is not a fresh import'
   end
 
   test 'should reject a mapping form that was superseded by a newer upload' do

--- a/test/functional/importer_controller_test.rb
+++ b/test/functional/importer_controller_test.rb
@@ -1060,6 +1060,93 @@ class ImporterControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
+  # --- Per-project isolation of match (refs #117121) ---
+  # Starting an import must only replace the user's previous import on the
+  # same project: an import the user has in progress on another project is
+  # independent and must not be discarded.
+
+  test 'should keep an import running on another project when a new one is matched' do
+    @iip.update!(csv_data: cross_project_csv)
+    post :result, params: batch_run_params
+    assert_redirected_to "/projects/#{@project.identifier}/importer/run"
+    settings_before = @iip.reload.settings
+    assert settings_before.present?
+
+    @other_project = create_other_project!
+    post_match!(@other_project,
+                "#,Subject,Tracker,Status,Priority\n" \
+                "70011,Other One,Defect,New,Critical\n")
+    assert_response :success
+
+    assert ImportInProgress.exists?(@iip.id),
+           'match on another project must not delete the running import'
+    @iip.reload
+    assert_equal settings_before, @iip.settings,
+                 'the running import must keep its stored mapping'
+    assert_equal 2, ImportInProgress.where(user_id: @user.id).count,
+                 'each project keeps its own import in progress'
+
+    # The interrupted project can still finish its import afterwards
+    post :run, params: { project_id: @project.identifier }
+    assert_redirected_to "/projects/#{@project.identifier}/importer/result"
+    assert_equal 3, @project.issues.where('subject LIKE ?', 'Cross%').count
+  end
+
+  test 'should replace the previous import when matched again on the same project' do
+    @iip.update!(csv_data: cross_project_csv)
+    post :result, params: batch_run_params
+    assert @iip.reload.settings.present?
+
+    post_match!(@project,
+                "#,Subject,Tracker,Status,Priority\n" \
+                "70012,Fresh One,Defect,New,Critical\n")
+    assert_response :success
+
+    rows = ImportInProgress.where(user_id: @user.id, project_id: @project.id)
+    assert_equal 1, rows.count, 'the same project keeps a single import in progress'
+    assert_includes rows.first.csv_data, 'Fresh One'
+    assert rows.first.settings.blank?, 'a re-matched import starts from scratch'
+  end
+
+  test 'should run imports on two projects independently to completion' do
+    a_csv = +"#,Subject,Tracker,Status,Priority\n"
+    b_csv = +"#,Subject,Tracker,Status,Priority\n"
+    8.times do |i|
+      a_csv << "#{70_101 + i},A-#{i + 1},Defect,New,Critical\n"
+      b_csv << "#{70_201 + i},B-#{i + 1},Defect,New,Critical\n"
+    end
+    @iip.update!(csv_data: a_csv)
+    post :result, params: batch_run_params
+
+    @other_project = create_other_project!
+    other_iip = ImportInProgress.create!(user: @user, project: @other_project,
+                                         csv_data: b_csv, created: DateTime.now,
+                                         encoding: 'UTF-8', col_sep: ',', quote_char: '"')
+    post :result, params: batch_run_params.merge(
+      project_id: @other_project.identifier,
+      import_timestamp: other_iip.created.strftime('%Y-%m-%d %H:%M:%S')
+    )
+
+    # Alternate the polling between the two projects until both finish
+    # (each batch imports at most 5 rows, so each import needs two runs)
+    10.times do
+      break if @iip.reload.finished && other_iip.reload.finished
+
+      [@project, @other_project].each do |project|
+        post :run, params: { project_id: project.identifier }
+      end
+    end
+
+    assert @iip.reload.finished, 'the first import must run to completion'
+    assert other_iip.reload.finished, 'the second import must run to completion'
+    assert_equal 8, @project.issues.where('subject LIKE ?', 'A-%').count
+    assert_equal 8, @other_project.issues.where('subject LIKE ?', 'B-%').count
+    assert_equal 0, @project.issues.where('subject LIKE ?', 'B-%').count,
+                 'no row may leak into the other project'
+    assert_equal 0, @other_project.issues.where('subject LIKE ?', 'A-%').count,
+                 'no row may leak into the other project'
+  end
+
   protected
 
   # A second project the import was NOT started on, fully able to receive
@@ -1078,6 +1165,23 @@ class ImporterControllerTest < ActionController::TestCase
       "1,Cross One,Defect,New,Critical\n" \
       "2,Cross Two,Defect,New,Critical\n" \
       "3,Cross Three,Defect,New,Critical\n"
+  end
+
+  # Uploads csv_data to the project's match action, as the import form does.
+  def post_match!(project, csv_data)
+    file = Tempfile.new(['test', '.csv'])
+    file.write(csv_data)
+    file.rewind
+    post :match, params: {
+      project_id: project.identifier,
+      file: Rack::Test::UploadedFile.new(file.path, 'text/csv'),
+      wrapper: '"',
+      splitter: ',',
+      encoding: 'UTF-8'
+    }
+  ensure
+    file.close
+    file.unlink
   end
 
   # Drives the batched import flow to completion: POST :result stores the

--- a/test/functional/importer_controller_test.rb
+++ b/test/functional/importer_controller_test.rb
@@ -15,6 +15,7 @@ class ImporterControllerTest < ActionController::TestCase
     @tracker.save!
     @project.trackers << @tracker
     @project.save!
+    @project.enable_module!(:importer)
     @role = Role.create! name: 'ADMIN', permissions: %i[import view_issues]
     @user = create_user!(@role, @project)
     @iip = create_iip_for_multivalues!(@user, @project)
@@ -964,7 +965,120 @@ class ImporterControllerTest < ActionController::TestCase
     assert_redirected_to project_importer_path(project_id: @project.identifier)
   end
 
+  # --- Cross-project protection (refs #117121) ---
+  # An import started on one project must not be visible or resumable through
+  # another project's URL: the batch target project is derived from the URL,
+  # so a foreign URL would import the remaining rows into the wrong project.
+  # run/result must also be covered by the :import permission (project module
+  # enabled and role permission).
+
+  test 'should not show run progress via another project URL' do
+    @other_project = create_other_project!
+    @iip.update!(csv_data: cross_project_csv)
+    post :result, params: batch_run_params
+    assert_redirected_to "/projects/#{@project.identifier}/importer/run"
+
+    get :run, params: { project_id: @other_project.identifier }
+    assert_redirected_to project_importer_path(project_id: @other_project.identifier)
+    assert flash[:error].present?,
+           'a foreign project URL must not show the progress page'
+  end
+
+  test 'should not process batches via another project URL' do
+    @other_project = create_other_project!
+    @iip.update!(csv_data: cross_project_csv)
+    post :result, params: batch_run_params
+
+    assert_no_difference 'Issue.count' do
+      post :run, params: { project_id: @other_project.identifier }
+    end
+    assert_redirected_to project_importer_path(project_id: @other_project.identifier)
+    assert_equal 0, @other_project.issues.count,
+                 'no row may be imported into the project from the URL'
+    assert_not @iip.reload.finished,
+               'the import must not advance through a foreign project URL'
+  end
+
+  test 'should not show the result of an import finished on another project' do
+    @other_project = create_other_project!
+    @iip.update!(csv_data: cross_project_csv)
+    run_import_to_completion(batch_run_params)
+    assert_response :success
+
+    get :result, params: { project_id: @other_project.identifier }
+    assert_response :success
+    assert flash[:error].present?,
+           'a foreign project URL must not show the import result'
+  end
+
+  test 'should not start an import whose mapping was submitted to another project' do
+    @other_project = create_other_project!
+    assert_no_difference 'Issue.count' do
+      post :result, params: batch_run_params.merge(project_id: @other_project.identifier)
+    end
+    assert_response :success
+    assert flash[:error].present?
+    assert @iip.reload.settings.blank?,
+           'the mapping must not be stored for a foreign project'
+  end
+
+  test 'should refuse the run page when the importer module is disabled on the project' do
+    @project.disable_module!(:importer)
+    get :run, params: { project_id: @project.identifier }
+    assert_response :forbidden
+  end
+
+  test 'should refuse to process a batch when the importer module is disabled on the project' do
+    @iip.update!(csv_data: cross_project_csv)
+    post :result, params: batch_run_params
+    @project.disable_module!(:importer)
+
+    assert_no_difference 'Issue.count' do
+      post :run, params: { project_id: @project.identifier }
+    end
+    assert_response :forbidden
+  end
+
+  test 'should refuse the result page when the importer module is disabled on the project' do
+    @project.disable_module!(:importer)
+    get :result, params: { project_id: @project.identifier }
+    assert_response :forbidden
+  end
+
+  test 'should refuse the run page for a user without the import permission' do
+    role = Role.create! name: 'NO_IMPORT', permissions: %i[view_issues]
+    user = User.new(firstname: 'No', lastname: 'Import', mail: 'no.import@example.com')
+    user.login = 'noimport'
+    membership = user.memberships.build(project: @project)
+    membership.roles << role
+    membership.principal = user
+    user.pref.auto_watch_on = nil if Redmine::VERSION.to_s.to_f >= 5.1
+    user.save!
+    User.stubs(:current).returns(user)
+
+    get :run, params: { project_id: @project.identifier }
+    assert_response :forbidden
+  end
+
   protected
+
+  # A second project the import was NOT started on, fully able to receive
+  # imported issues (importer module enabled, same tracker), so the
+  # cross-project tests fail loudly if rows leak into it.
+  def create_other_project!
+    project = Project.create! name: 'other', identifier: 'importer_other_project'
+    project.trackers << @tracker unless project.trackers.include?(@tracker)
+    project.save!
+    project.enable_module!(:importer)
+    project
+  end
+
+  def cross_project_csv
+    "#,Subject,Tracker,Status,Priority\n" \
+      "1,Cross One,Defect,New,Critical\n" \
+      "2,Cross Two,Defect,New,Critical\n" \
+      "3,Cross Three,Defect,New,Critical\n"
+  end
 
   # Drives the batched import flow to completion: POST :result stores the
   # settings, then POST :run is repeated until it redirects to the result

--- a/test/functional/importer_controller_test.rb
+++ b/test/functional/importer_controller_test.rb
@@ -943,7 +943,49 @@ class ImporterControllerTest < ActionController::TestCase
     assert response.body.include?(I18n.t(:error_issue_id_taken))
   end
 
-  test 'should reject re-submitting the mapping form for a started import' do
+  # --- Mapping form resubmission (refs #117120) ---
+  # Pressing the browser's back button from the progress page and submitting
+  # the mapping form again must never restart the import (that would
+  # duplicate the already imported rows), but it must not cut the running
+  # import off with a misleading "superseded" error either: the user is sent
+  # back to the import they already started.
+
+  test 'should redirect a resubmitted mapping form to the progress page while the import is running' do
+    ImporterController.any_instance.stubs(:max_items_per_request).returns(1)
+    @iip.update!(csv_data: "#,Subject,Tracker,Status,Priority\n" \
+                           "1,Resubmit One,Defect,New,Critical\n" \
+                           "2,Resubmit Two,Defect,New,Critical\n" \
+                           "3,Resubmit Three,Defect,New,Critical\n")
+    params = batch_run_params
+
+    post :result, params: params
+    assert_redirected_to "/projects/#{@project.identifier}/importer/run"
+    post :run, params: { project_id: @project.identifier }
+    assert_equal 1, @iip.reload.position
+
+    # Browser back + "Import" again resubmits the very same mapping form
+    assert_no_difference 'Issue.count' do
+      post :result, params: params
+    end
+    assert_redirected_to "/projects/#{@project.identifier}/importer/run"
+    assert_nil flash[:error], 'a resubmitted form of a running import must not show an error'
+    assert_equal I18n.t(:notice_import_already_running), flash[:notice]
+    @iip.reload
+    assert_not @iip.finished, 'the running import must not be cut off'
+    assert_equal 1, @iip.position, 'the import progress must be preserved'
+
+    # The progress page's polling picks the import up where it left off
+    post :run, params: { project_id: @project.identifier }
+    assert_redirected_to "/projects/#{@project.identifier}/importer/run"
+    post :run, params: { project_id: @project.identifier }
+    assert_redirected_to "/projects/#{@project.identifier}/importer/result"
+    %w[One Two Three].each do |n|
+      assert_equal 1, Issue.where(subject: "Resubmit #{n}").count,
+                   "row 'Resubmit #{n}' must be imported exactly once"
+    end
+  end
+
+  test 'should redirect a resubmitted mapping form to the result page after the import finished' do
     @iip.update!(csv_data: "#,Subject,Tracker,Status,Priority\n" \
                            "1,Batch One,Defect,New,Critical\n")
     params = batch_run_params
@@ -951,12 +993,29 @@ class ImporterControllerTest < ActionController::TestCase
     run_import_to_completion(params)
     assert_equal 1, Issue.where(subject: 'Batch One').count
 
-    # Re-submitting the same mapping form must not restart the import
+    # Re-submitting the same mapping form must not restart the import; the
+    # user is shown the report of the import that already ran instead.
     assert_no_difference 'Issue.count' do
       post :result, params: params
-      assert_response :success
-      assert flash[:error].present?
     end
+    assert_redirected_to "/projects/#{@project.identifier}/importer/result"
+    assert_nil flash[:error],
+               'a resubmitted form of a finished import must not show an error'
+  end
+
+  test 'should reject a mapping form that was superseded by a newer upload' do
+    params = batch_run_params # captures the current form timestamp
+
+    # Uploading a new file replaces the ImportInProgress record (see :match),
+    # so the old form's timestamp no longer matches: that form really was
+    # superseded by another import and must keep being rejected.
+    @iip.update!(created: @iip.created + 1.hour)
+
+    assert_no_difference 'Issue.count' do
+      post :result, params: params
+    end
+    assert_response :success
+    assert_equal I18n.t(:error_import_superseded), flash[:error]
   end
 
   test 'run without import in progress should redirect to importer index' do

--- a/test/performance/import_benchmark_test.rb
+++ b/test/performance/import_benchmark_test.rb
@@ -41,6 +41,7 @@ class ImportBenchmarkTest < ActionController::TestCase
     @tracker.save!
     @project.trackers << @tracker
     @project.save!
+    @project.enable_module!(:importer)
     IssuePriority.find_or_create_by!(name: 'Critical')
     @role = Role.create! name: 'BENCH', permissions: %i[import view_issues]
     @user = create_user!(@role, @project)
@@ -123,6 +124,7 @@ class ImportBenchmarkTest < ActionController::TestCase
     ImportInProgress.where(user_id: @user.id).delete_all
     iip = ImportInProgress.new
     iip.user = @user
+    iip.project = @project
     iip.csv_data = csv_data
     iip.created = DateTime.now
     iip.encoding = 'UTF-8'


### PR DESCRIPTION
## Summary

Follow-up to #51. During exploratory testing of the batched import we found that opening the import progress URL under a different project (e.g. a project where the importer module is disabled) returned HTTP 200 and showed the progress of an import running in another project. Since the progress page posts the next batch to the URL it was opened under, the remaining rows could end up being written to an unrelated project.

## Changes

- Add `project_id` to `ImportInProgress` (migration 003) and record the originating project when the import is started (`match`)
- Look up the in-progress import scoped by user **and** project (`current_import_in_progress`). A URL pointing at a different project now behaves exactly like "no import in progress" (fail-closed): no progress page, no batch execution, no writes
- Add `before_action :authorize` to all actions and extend the `:import` permission in `init.rb` to `index match result run` (previously no action was authorized)
- (Review follow-up) `match` now also deletes and creates the `ImportInProgress` scoped by user **and** project: starting an import on one project no longer discards an import the same user has in progress on another project. Each user gets one import in progress per project, and imports on different projects run independently

## Tests

- First commit adds 8 failing tests (cross-project GET/POST run, module disabled, permission missing); second commit turns them green
- Review follow-up adds 3 more (an import running on another project survives `match`, same-project `match` still resets, two imports complete independently)
- `rake redmine:plugins:test NAME=redmine_importer`: 71 runs / 0 failures on Redmine 6.1.1

## Notes for reviewers

- In-progress imports that predate this change have `project_id = NULL` and become invisible from every project after upgrading. This is intentional (fail-closed): the originating project is unknown, so there is nothing to backfill. Re-uploading the CSV recovers, and the orphaned rows are reclaimed by the existing 3-day cleanup
- `authorize` now also covers `index` / `match`. Limiting it to `run` / `result` would be possible but leaves a hole, so the wider scope is preferred
- When polling is rejected, the request gets an HTML redirect and the progress bar stalls silently. That is a pre-existing limitation of the polling error handling and is out of scope here

🤖 Generated with [Claude Code](https://claude.com/claude-code)
