### PR TITLE
fix: Redirect a resubmitted mapping form to the import it already started

### DIFF
--- a/app/controllers/importer_controller.rb
+++ b/app/controllers/importer_controller.rb
@@ -374,6 +374,7 @@ class ImporterController < ApplicationController
     # once it finished (#117120).
     if iip.settings.present?
       if iip.finished?
+        flash[:notice] = l(:notice_import_already_finished)
         redirect_to project_importer_result_path(project_id: @project)
       else
         flash[:notice] = l(:notice_import_already_running)

--- a/app/controllers/importer_controller.rb
+++ b/app/controllers/importer_controller.rb
@@ -365,9 +365,20 @@ class ImporterController < ApplicationController
     end
     # A mapping form may only be submitted once per uploaded file (the legacy
     # implementation guaranteed this by deleting the iip after importing);
-    # re-submitting would restart the import and duplicate issues.
+    # re-submitting would restart the import and duplicate issues. The
+    # timestamp matched above, so this is the form of the import the user
+    # already started (typically the browser's back button from the progress
+    # page): send them back to that import instead of failing with the
+    # misleading "superseded" error — to the progress page while it is
+    # running, so polling resumes from the saved position, or to its report
+    # once it finished (#117120).
     if iip.settings.present?
-      flash[:error] = l(:error_import_superseded)
+      if iip.finished?
+        redirect_to project_importer_result_path(project_id: @project)
+      else
+        flash[:notice] = l(:notice_import_already_running)
+        redirect_to project_importer_run_path(project_id: @project)
+      end
       return
     end
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -43,6 +43,7 @@ de:
     label_importer_use_issue_id: "Import using issue ids"
     error_no_import_in_progress: "No import is currently in progress"
     error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
+    notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
     error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
     error_issue_id_taken: "This issue id has already been taken."
     error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -44,6 +44,7 @@ de:
     error_no_import_in_progress: "No import is currently in progress"
     error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
     notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
+    notice_import_already_finished: "The import you submitted has already finished, so its report is shown. No rows were imported again."
     error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
     error_issue_id_taken: "This issue id has already been taken."
     error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,7 @@ en:
 
   error_no_import_in_progress: "No import is currently in progress"
   error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
+  notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
   error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
   error_issue_id_taken: "This issue id has already been taken."
   error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,6 +52,7 @@ en:
   error_no_import_in_progress: "No import is currently in progress"
   error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
   notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
+  notice_import_already_finished: "The import you submitted has already finished, so its report is shown. No rows were imported again."
   error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
   error_issue_id_taken: "This issue id has already been taken."
   error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -53,6 +53,7 @@ ja:
   error_no_import_in_progress: "現在進行中のインポートがありません。"
   error_import_superseded: "このインポートは別のインポートにより無効になりました。"
   notice_import_already_running: "実行中のインポートがあるため進捗画面を表示しています。残りの行は引き続き取り込まれます。"
+  notice_import_already_finished: "送信されたインポートは既に完了しているため、結果画面を表示しています。行が再度取り込まれることはありません。"
   error_must_map_id_column: "チケットIDを使用してインポートする場合、対応するIDの列を指定してください。"
   error_issue_id_taken: "このチケットIDは既に使用されています。"
   error_csv_no_data: "CSVにデータ行がありません。ファイルのエンコーディングを確認してください。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -52,6 +52,7 @@ ja:
 
   error_no_import_in_progress: "現在進行中のインポートがありません。"
   error_import_superseded: "このインポートは別のインポートにより無効になりました。"
+  notice_import_already_running: "実行中のインポートがあるため進捗画面を表示しています。残りの行は引き続き取り込まれます。"
   error_must_map_id_column: "チケットIDを使用してインポートする場合、対応するIDの列を指定してください。"
   error_issue_id_taken: "このチケットIDは既に使用されています。"
   error_csv_no_data: "CSVにデータ行がありません。ファイルのエンコーディングを確認してください。"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -41,6 +41,7 @@ pt-BR:
   error_no_import_in_progress: "No import is currently in progress"
   error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
   notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
+  notice_import_already_finished: "The import you submitted has already finished, so its report is shown. No rows were imported again."
   error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
   error_issue_id_taken: "This issue id has already been taken."
   error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -40,6 +40,7 @@ pt-BR:
   label_importer_use_issue_id: "Import using issue ids"
   error_no_import_in_progress: "No import is currently in progress"
   error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
+  notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
   error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
   error_issue_id_taken: "This issue id has already been taken."
   error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -43,6 +43,7 @@ ru:
   label_importer_use_issue_id: "Import using issue ids"
   error_no_import_in_progress: "No import is currently in progress"
   error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
+  notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
   error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
   error_issue_id_taken: "This issue id has already been taken."
   error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -44,6 +44,7 @@ ru:
   error_no_import_in_progress: "No import is currently in progress"
   error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
   notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
+  notice_import_already_finished: "The import you submitted has already finished, so its report is shown. No rows were imported again."
   error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
   error_issue_id_taken: "This issue id has already been taken."
   error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -44,6 +44,7 @@ zh:
   label_importer_use_issue_id: "Import using issue ids"
   error_no_import_in_progress: "No import is currently in progress"
   error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
+  notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
   error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
   error_issue_id_taken: "This issue id has already been taken."
   error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -45,6 +45,7 @@ zh:
   error_no_import_in_progress: "No import is currently in progress"
   error_import_superseded: "You seem to have started another import since starting this one. This import cannot be completed"
   notice_import_already_running: "An import you started is still running, so its progress is shown. The remaining rows will continue to be imported."
+  notice_import_already_finished: "The import you submitted has already finished, so its report is shown. No rows were imported again."
   error_must_map_id_column: "You must specify a column mapping for id when importing using provided issue ids."
   error_issue_id_taken: "This issue id has already been taken."
   error_csv_no_data: "No data line in your CSV, check the encoding of the file"

--- a/test/functional/importer_controller_test.rb
+++ b/test/functional/importer_controller_test.rb
@@ -1001,6 +1001,8 @@ class ImporterControllerTest < ActionController::TestCase
     assert_redirected_to "/projects/#{@project.identifier}/importer/result"
     assert_nil flash[:error],
                'a resubmitted form of a finished import must not show an error'
+    assert_equal I18n.t(:notice_import_already_finished), flash[:notice],
+                 'the user must be told the shown report is not a fresh import'
   end
 
   test 'should reject a mapping form that was superseded by a newer upload' do

--- a/test/functional/importer_controller_test.rb
+++ b/test/functional/importer_controller_test.rb
@@ -943,7 +943,49 @@ class ImporterControllerTest < ActionController::TestCase
     assert response.body.include?(I18n.t(:error_issue_id_taken))
   end
 
-  test 'should reject re-submitting the mapping form for a started import' do
+  # --- Mapping form resubmission (refs #117120) ---
+  # Pressing the browser's back button from the progress page and submitting
+  # the mapping form again must never restart the import (that would
+  # duplicate the already imported rows), but it must not cut the running
+  # import off with a misleading "superseded" error either: the user is sent
+  # back to the import they already started.
+
+  test 'should redirect a resubmitted mapping form to the progress page while the import is running' do
+    ImporterController.any_instance.stubs(:max_items_per_request).returns(1)
+    @iip.update!(csv_data: "#,Subject,Tracker,Status,Priority\n" \
+                           "1,Resubmit One,Defect,New,Critical\n" \
+                           "2,Resubmit Two,Defect,New,Critical\n" \
+                           "3,Resubmit Three,Defect,New,Critical\n")
+    params = batch_run_params
+
+    post :result, params: params
+    assert_redirected_to "/projects/#{@project.identifier}/importer/run"
+    post :run, params: { project_id: @project.identifier }
+    assert_equal 1, @iip.reload.position
+
+    # Browser back + "Import" again resubmits the very same mapping form
+    assert_no_difference 'Issue.count' do
+      post :result, params: params
+    end
+    assert_redirected_to "/projects/#{@project.identifier}/importer/run"
+    assert_nil flash[:error], 'a resubmitted form of a running import must not show an error'
+    assert_equal I18n.t(:notice_import_already_running), flash[:notice]
+    @iip.reload
+    assert_not @iip.finished, 'the running import must not be cut off'
+    assert_equal 1, @iip.position, 'the import progress must be preserved'
+
+    # The progress page's polling picks the import up where it left off
+    post :run, params: { project_id: @project.identifier }
+    assert_redirected_to "/projects/#{@project.identifier}/importer/run"
+    post :run, params: { project_id: @project.identifier }
+    assert_redirected_to "/projects/#{@project.identifier}/importer/result"
+    %w[One Two Three].each do |n|
+      assert_equal 1, Issue.where(subject: "Resubmit #{n}").count,
+                   "row 'Resubmit #{n}' must be imported exactly once"
+    end
+  end
+
+  test 'should redirect a resubmitted mapping form to the result page after the import finished' do
     @iip.update!(csv_data: "#,Subject,Tracker,Status,Priority\n" \
                            "1,Batch One,Defect,New,Critical\n")
     params = batch_run_params
@@ -951,12 +993,29 @@ class ImporterControllerTest < ActionController::TestCase
     run_import_to_completion(params)
     assert_equal 1, Issue.where(subject: 'Batch One').count
 
-    # Re-submitting the same mapping form must not restart the import
+    # Re-submitting the same mapping form must not restart the import; the
+    # user is shown the report of the import that already ran instead.
     assert_no_difference 'Issue.count' do
       post :result, params: params
-      assert_response :success
-      assert flash[:error].present?
     end
+    assert_redirected_to "/projects/#{@project.identifier}/importer/result"
+    assert_nil flash[:error],
+               'a resubmitted form of a finished import must not show an error'
+  end
+
+  test 'should reject a mapping form that was superseded by a newer upload' do
+    params = batch_run_params # captures the current form timestamp
+
+    # Uploading a new file replaces the ImportInProgress record (see :match),
+    # so the old form's timestamp no longer matches: that form really was
+    # superseded by another import and must keep being rejected.
+    @iip.update!(created: @iip.created + 1.hour)
+
+    assert_no_difference 'Issue.count' do
+      post :result, params: params
+    end
+    assert_response :success
+    assert_equal I18n.t(:error_import_superseded), flash[:error]
   end
 
   test 'run without import in progress should redirect to importer index' do


### PR DESCRIPTION
## Summary

Follow-up to #51, stacked on #54 (retarget to `batch-import` once #54 is merged). During exploratory testing of the batched import we found that pressing the browser's Back button during a large import and re-submitting the mapping form showed the misleading message "This import was superseded by another import." and the running import stopped partway through, leaving the remaining rows unimported.

## Changes

Re-submitting the mapping form of an import that was already started no longer invalidates it. Instead:

- **Import still running**: redirect to the progress page with a notice ("An import is already running..."); polling resumes from the saved position, so nothing is cut off
- **Import already finished**: redirect to the result page with a notice explaining that the resubmission did not import anything again (review follow-up), consistent with how the progress page already forwards finished imports to the result
- A genuinely superseded form (a *newer* upload invalidated it, i.e. timestamp mismatch) keeps the existing `error_import_superseded` behavior — there the message matches reality. This boundary is pinned by a new test
- New locale keys `notice_import_already_running` / `notice_import_already_finished` added to all six locale files (translated for `en` / `ja`; `de` / `pt-BR` / `ru` / `zh` carry the English string, matching how every other key is handled there — review follow-up)

## Tests

- First commit adds the failing resubmission tests (red: 2 failures); second commit turns them green
- One existing test expectation changed: resubmitting after completion now expects a redirect to the result page instead of `flash[:error]` — the "must not restart the import" assertion (`assert_no_difference 'Issue.count'`) is kept
- `rake redmine:plugins:test NAME=redmine_importer`: 73 runs / 0 failures on Redmine 6.1.1 (rebased on #54)

## Notes for reviewers

- The cross-project scoping from #54 still applies: a resubmission under a different project's URL does not reach the redirect branch and keeps behaving as "no import in progress"
- The notice on the progress page survives only one request (plain Rails flash); it disappears on the run→result redirect when the import finishes. `flash.keep` could be added if longer visibility is wanted
- The silent stall of polling when a request gets an HTML redirect is a pre-existing limitation of the polling error handling and is out of scope here

🤖 Generated with [Claude Code](https://claude.com/claude-code)
