### PR TITLE
Bump version to 3.0.0

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -11,7 +11,7 @@ Redmine::Plugin.register :redmine_importer do
   name 'Issue Importer'
   author 'Martin Liu / Leo Hourvitz / Stoyan Zhekov / Jérôme Bataille / Agileware Inc.'
   description 'Issue import plugin for Redmine.'
-  version '2.1.0'
+  version '3.0.0'
 
   settings default: { 'max_csv_rows' => '5000' },
            partial: 'settings/redmine_importer_settings'


### PR DESCRIPTION
Bump plugin version to 3.0.0 for the release including #51 and #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)